### PR TITLE
#6 Add hands-on CLI guide (English + Japanese)

### DIFF
--- a/docs/ja/user-guides/cli/README.md
+++ b/docs/ja/user-guides/cli/README.md
@@ -1,0 +1,413 @@
+# Ankiniki CLI — ハンズオンガイド
+
+ターミナルから Anki フラッシュカードを作成・学習・管理するための `ankiniki` CLIツール実践ガイドです。
+
+> **English version:** [English guide here](../../../user-guides/cli/README.md)
+
+---
+
+## 事前準備
+
+CLI を使用する前に以下が必要です。
+
+1. **Anki デスクトップアプリ**が起動していること
+2. **AnkiConnect アドオン**が Anki にインストールされていること（コード: `2055492159`）
+   - Anki → ツール → アドオン → アドオンを取得 → コードを入力
+3. **Ankiniki バックエンドサーバー**が起動していること（import コマンドで必要）
+   ```bash
+   # プロジェクトルートから
+   npm run dev --workspace=@ankiniki/backend
+   # サーバーが http://localhost:3001 で起動します
+   ```
+
+---
+
+## インストール
+
+```bash
+# プロジェクトルートから CLI をビルド
+npm run build --workspace=@ankiniki/cli
+
+# ビルドなしで直接実行（開発モード）
+cd apps/cli
+npm run dev -- <コマンド>
+
+# ビルド後に実行
+node apps/cli/dist/index.js <コマンド>
+```
+
+---
+
+## クイックスタート
+
+```bash
+# 接続確認
+ankiniki config --show
+
+# はじめてのカードを追加
+ankiniki add "My Deck" "クロージャとは？" "外側のスコープの変数を参照する関数"
+
+# デッキ一覧を表示
+ankiniki list
+
+# デッキを学習する
+ankiniki study "My Deck"
+```
+
+---
+
+## コマンド一覧
+
+### `add` — フラッシュカードを作成
+
+**基本形:**
+
+```bash
+ankiniki add [デッキ名] [表面] [裏面]
+```
+
+**使用例:**
+
+```bash
+# 引数で直接指定（最速）
+ankiniki add "JavaScript" "ホイスティングとは？" "宣言をスコープの先頭に移動する動作"
+
+# タグとモデルを指定
+ankiniki add "Rust" "所有権とは？" "各値には必ず1つの所有者がある" \
+  --tags "rust,memory,ownership" \
+  --model "Basic"
+
+# デフォルトデッキを使用（config で設定済みの場合）
+ankiniki add "モナドとは？" "自己関手の圏におけるモノイド対象"
+
+# インタラクティブモード — すべてを対話形式で入力
+ankiniki add --interactive
+ankiniki add -i
+```
+
+**オプション一覧:**
+
+| オプション        | 短縮形 | 説明                              |
+| ----------------- | ------ | --------------------------------- |
+| `--tags <tags>`   | `-t`   | タグ（カンマ区切り）              |
+| `--model <model>` | `-m`   | カードモデル（デフォルト: Basic） |
+| `--interactive`   | `-i`   | 対話形式で入力                    |
+
+**インタラクティブモード**では表面・裏面の入力に `$EDITOR` が開きます。複数行のコードスニペットを書くときに便利です。
+
+---
+
+### `study` — ターミナルで学習セッション
+
+表面を表示 → Enter で裏面を表示 → 1〜4で評価、という流れで学習します。
+
+```bash
+ankiniki study [デッキ名]
+```
+
+**使用例:**
+
+```bash
+# 特定のデッキを学習（デフォルト5枚）
+ankiniki study "JavaScript"
+
+# 20枚をランダム順で学習
+ankiniki study "JavaScript" --count 20 --random
+ankiniki study "JavaScript" -n 20 --random
+
+# デッキ名を省略すると選択肢が表示される
+ankiniki study
+```
+
+**オプション一覧:**
+
+| オプション    | 短縮形 | 説明                      |
+| ------------- | ------ | ------------------------- |
+| `--count <n>` | `-n`   | 学習枚数（デフォルト: 5） |
+| `--random`    |        | カードをシャッフル        |
+
+**評価基準:**
+
+| 選択肢   | 意味                 |
+| -------- | -------------------- |
+| ❌ Again | わからなかった       |
+| 🔶 Hard  | わかったが難しかった |
+| ✅ Good  | わかった             |
+| 🚀 Easy  | 簡単すぎた           |
+
+> **注意:** このモードは Anki のスケジューリングに関係なく、デッキ内のカードを取得します。Anki の間隔反復スケジュールに従って学習する場合は、Anki デスクトップで通常どおりレビューしてください。
+
+---
+
+### `list` — デッキとカードの一覧表示
+
+```bash
+ankiniki list                          # デッキ一覧（デフォルト）
+ankiniki list --decks                  # 同上
+ankiniki list --cards "My Deck"        # デッキ内のカードを表示
+ankiniki list --cards "My Deck" --limit 50
+```
+
+**使用例:**
+
+```bash
+# 全デッキをカード数つきで表示
+ankiniki list
+
+# デッキ内のカードを確認（最初の10枚）
+ankiniki list --cards "JavaScript"
+
+# より多く表示
+ankiniki list --cards "JavaScript" --limit 50
+```
+
+**オプション一覧:**
+
+| オプション         | 短縮形 | 説明                           |
+| ------------------ | ------ | ------------------------------ |
+| `--decks`          | `-d`   | デッキ一覧を表示               |
+| `--cards <デッキ>` | `-c`   | デッキ内のカードを表示         |
+| `--limit <n>`      | `-l`   | 表示件数上限（デフォルト: 10） |
+
+---
+
+### `config` — 設定管理
+
+```bash
+ankiniki config               # 現在の設定を表示（デフォルト）
+ankiniki config --show
+ankiniki config --edit        # 対話形式で編集
+ankiniki config --set key=value
+ankiniki config --reset       # デフォルトに戻す
+```
+
+**設定項目:**
+
+| キー             | デフォルト値            | 説明                                           |
+| ---------------- | ----------------------- | ---------------------------------------------- |
+| `ankiConnectUrl` | `http://localhost:8765` | AnkiConnect API のエンドポイント               |
+| `serverUrl`      | `http://localhost:3001` | Ankiniki バックエンド（import コマンドで使用） |
+| `defaultDeck`    | `Default`               | デッキ未指定時に使用するデッキ名               |
+| `defaultModel`   | `Basic`                 | モデル未指定時に使用するカードモデル           |
+| `debugMode`      | `false`                 | 詳細ログ出力                                   |
+
+**使用例:**
+
+```bash
+# 現在の設定と接続状態を確認
+ankiniki config --show
+
+# デフォルトデッキを変更
+ankiniki config --set defaultDeck=JavaScript
+
+# バックエンドの URL を変更
+ankiniki config --set serverUrl=http://localhost:3001
+
+# 対話形式で編集（デッキ・モデルの選択肢が表示される）
+ankiniki config --edit
+
+# すべての設定をデフォルトに戻す
+ankiniki config --reset
+```
+
+設定は `~/.ankiniki.json` に保存されます。
+
+---
+
+### `import` — ファイルから一括インポート
+
+CSV・JSON・Markdown ファイルから複数のカードを一度にインポートします。**ファイル拡張子から形式が自動判別されます。**
+
+```bash
+ankiniki import <ファイル> [オプション]
+```
+
+#### CSV インポート
+
+```bash
+# 拡張子 .csv から自動判別
+ankiniki import cards.csv
+
+# プレビュー（カードは作成されない）
+ankiniki import cards.csv --preview
+
+# デフォルトデッキとタグを指定
+ankiniki import cards.csv --deck "JavaScript" --tags "imported,js"
+```
+
+**CSV 形式:**
+
+```csv
+Front,Back,Deck,Tags,Model
+"クロージャとは？","外側のスコープの変数を参照する関数","JavaScript","js,closures","Basic"
+"ホイスティングとは？","宣言をスコープの先頭に移動する動作","JavaScript","js","Basic"
+```
+
+シンプルな形式（デッキ・タグは CLI フラグで指定）:
+
+```csv
+Front,Back
+"クロージャとは？","外側のスコープの変数を参照する関数"
+```
+
+カスタム列名を使う場合:
+
+```bash
+ankiniki import cards.csv \
+  --mapping '{"front":"質問","back":"回答","deck":"教科","tags":"タグ"}'
+```
+
+---
+
+#### JSON インポート
+
+```bash
+# 拡張子 .json から自動判別
+ankiniki import cards.json
+
+ankiniki import cards.json --preview
+ankiniki import cards.json --deck "Rust" --tags "rust"
+```
+
+**JSON 形式（配列）:**
+
+```json
+[
+  {
+    "front": "所有権とは？",
+    "back": "Rust では各値に必ず1つの所有者がある。",
+    "deck": "Rust",
+    "tags": ["rust", "memory"]
+  },
+  {
+    "front": "借用とは？",
+    "back": "所有権を移さずに値を一時的に使うこと。",
+    "deck": "Rust",
+    "tags": ["rust", "memory"]
+  }
+]
+```
+
+**JSON 形式（デフォルト値つきオブジェクト）:**
+
+```json
+{
+  "deck_name": "Rust",
+  "default_tags": ["rust"],
+  "default_model": "Basic",
+  "cards": [
+    { "front": "所有権とは？", "back": "各値に必ず1つの所有者がある。" },
+    { "front": "借用とは？", "back": "所有権を移さずに値を一時的に使うこと。" }
+  ]
+}
+```
+
+---
+
+#### Markdown インポート
+
+```bash
+# 拡張子 .md から自動判別
+ankiniki import cards.md
+
+ankiniki import cards.md --preview
+ankiniki import cards.md --deck "TypeScript"
+```
+
+**Markdown 形式:**
+
+```markdown
+---
+deck: Programming::TypeScript
+tags: [typescript, types]
+---
+
+## 型アサーションとは？
+
+**Front:** TypeScript における型アサーションとは何ですか？
+**Back:** コンパイラに対して「この値はこの型として扱え」と指示する構文。`as` または `<Type>` を使う。
+
+## ユニオン型とは？
+
+**Front:** ユニオン型とは何ですか？
+**Back:** 複数の型のいずれかを取れる型。`A | B` のように書く。
+```
+
+- フロントマター（`---` ブロック）でデフォルトのデッキとタグを設定
+- `##` 見出しごとに1枚のカード
+- 各セクションに `**Front:**` と `**Back:**` が必要
+
+---
+
+#### インポート共通オプション
+
+| オプション           | 短縮形 | 説明                                         |
+| -------------------- | ------ | -------------------------------------------- |
+| `--format <fmt>`     | `-f`   | 形式を強制指定: `csv` / `json` / `markdown`  |
+| `--deck <デッキ>`    |        | デフォルトデッキ（ファイル内の設定を上書き） |
+| `--model <モデル>`   |        | カードモデル（デフォルト: Basic）            |
+| `--tags <タグ>`      |        | 追加タグ（カンマ区切り）                     |
+| `--preview`          | `-p`   | ドライラン — 実際にはインポートしない        |
+| `--dry-run`          |        | `--preview` と同じ                           |
+| `--delimiter <文字>` | `-d`   | CSV 区切り文字（デフォルト: `,`）            |
+| `--mapping <json>`   |        | CSV カスタム列マッピング                     |
+
+---
+
+### `import mapping` — 形式サンプルを表示
+
+```bash
+ankiniki import mapping
+```
+
+---
+
+## よくあるワークフロー
+
+### コーディング中にその場でカードを追加する
+
+```bash
+# Rust を調べていて気づいたことをすぐ追加
+ankiniki add "Rust" \
+  "Option::unwrap_or_else は何をする？" \
+  "値を返す。値がなければクロージャを呼んでフォールバック値を計算する。" \
+  --tags "rust,option,error-handling"
+
+# 追加されたか確認
+ankiniki list --cards "Rust"
+```
+
+### 読書ノートを一括インポート
+
+```bash
+# ドキュメントを読みながら Markdown でカードを書いて、まとめてインポート
+ankiniki import study-notes.md --preview   # まずプレビューで確認
+ankiniki import study-notes.md
+```
+
+### ターミナルで毎日のレビュー
+
+```bash
+# メインデッキからランダムに10枚
+ankiniki study "Programming" --count 10 --random
+```
+
+### 新しいマシンでの設定
+
+```bash
+ankiniki config --edit   # ankiConnectUrl, serverUrl, defaultDeck を設定
+ankiniki config --show   # 接続確認
+```
+
+---
+
+## トラブルシューティング
+
+| 問題                       | 解決策                                                                                  |
+| -------------------------- | --------------------------------------------------------------------------------------- |
+| `Cannot connect to Anki`   | Anki デスクトップが起動しているか、AnkiConnect がインストールされているか確認           |
+| `Deck does not exist`      | Anki でデッキを先に作成するか、デッキ名のスペルを確認                                   |
+| `Import failed: API Error` | バックエンドサーバーが起動しているか確認（`npm run dev --workspace=@ankiniki/backend`） |
+| `Model does not exist`     | `ankiniki list` でモデル名を確認するか、`Basic` を使用                                  |
+
+AnkiConnect の動作確認: ブラウザで `http://localhost:8765` を開くとバージョン番号が表示されます。

--- a/docs/user-guides/cli/README.md
+++ b/docs/user-guides/cli/README.md
@@ -1,0 +1,413 @@
+# Ankiniki CLI — Hands-On Guide
+
+A practical guide to using the `ankiniki` command-line tool to create, study, and manage Anki flashcards from your terminal.
+
+> **Japanese version:** [日本語版はこちら](../../ja/user-guides/cli/README.md)
+
+---
+
+## Prerequisites
+
+Before using the CLI you need:
+
+1. **Anki desktop** running on your machine
+2. **AnkiConnect addon** installed in Anki (code: `2055492159`)
+   - Anki → Tools → Add-ons → Get Add-ons → enter the code
+3. **Ankiniki backend server** running (for import commands)
+   ```bash
+   # From the project root
+   npm run dev --workspace=@ankiniki/backend
+   # Server starts at http://localhost:3001
+   ```
+
+---
+
+## Installation
+
+```bash
+# From the project root, build the CLI
+npm run build --workspace=@ankiniki/cli
+
+# Run directly (dev mode, no build needed)
+cd apps/cli
+npm run dev -- <command>
+
+# Or after build
+node apps/cli/dist/index.js <command>
+```
+
+---
+
+## Quick Start
+
+```bash
+# Check everything is working
+ankiniki config --show
+
+# Add your first card
+ankiniki add "My Deck" "What is a closure?" "A function that captures its enclosing scope"
+
+# List your decks
+ankiniki list
+
+# Study a deck
+ankiniki study "My Deck"
+```
+
+---
+
+## Commands
+
+### `add` — Create a flashcard
+
+**One-liner:**
+
+```bash
+ankiniki add [deck] [front] [back]
+```
+
+**Examples:**
+
+```bash
+# Positional arguments (fastest)
+ankiniki add "JavaScript" "What is hoisting?" "Moving declarations to the top of scope"
+
+# With tags and model
+ankiniki add "Rust" "What is ownership?" "Each value has one owner" \
+  --tags "rust,memory,ownership" \
+  --model "Basic"
+
+# Use default deck (set via config)
+ankiniki add "What is a monad?" "A monoid in the category of endofunctors"
+
+# Interactive mode — prompts for everything
+ankiniki add --interactive
+ankiniki add -i
+```
+
+**Options:**
+
+| Option            | Short | Description                        |
+| ----------------- | ----- | ---------------------------------- |
+| `--tags <tags>`   | `-t`  | Comma-separated tags               |
+| `--model <model>` | `-m`  | Card model (default: Basic)        |
+| `--interactive`   | `-i`  | Interactive prompts for all fields |
+
+**Interactive mode** opens your `$EDITOR` for front/back content — useful for multi-line code snippets.
+
+---
+
+### `study` — Quick study session
+
+Starts an in-terminal study session: shows the front, waits for Enter, reveals the back, asks you to rate 1–4.
+
+```bash
+ankiniki study [deck]
+```
+
+**Examples:**
+
+```bash
+# Study a specific deck (5 cards by default)
+ankiniki study "JavaScript"
+
+# Study 20 cards in random order
+ankiniki study "JavaScript" --count 20 --random
+ankiniki study "JavaScript" -n 20 --random
+
+# Omit deck to pick from a list
+ankiniki study
+```
+
+**Options:**
+
+| Option        | Short | Description                           |
+| ------------- | ----- | ------------------------------------- |
+| `--count <n>` | `-n`  | Number of cards to study (default: 5) |
+| `--random`    |       | Shuffle cards                         |
+
+**Rating scale:**
+
+| Choice   | Meaning               |
+| -------- | --------------------- |
+| ❌ Again | Didn't know it        |
+| 🔶 Hard  | Got it, but difficult |
+| ✅ Good  | Knew it               |
+| 🚀 Easy  | Too easy              |
+
+> **Note:** This mode picks cards from the deck regardless of Anki's scheduling. To use Anki's spaced repetition schedule, review cards in Anki desktop as usual.
+
+---
+
+### `list` — Browse decks and cards
+
+```bash
+ankiniki list                        # list all decks (default)
+ankiniki list --decks                # same as above
+ankiniki list --cards "My Deck"      # list cards in a deck
+ankiniki list --cards "My Deck" --limit 50
+```
+
+**Examples:**
+
+```bash
+# See all decks with card counts
+ankiniki list
+
+# Browse cards in a deck (first 10)
+ankiniki list --cards "JavaScript"
+
+# See more cards
+ankiniki list --cards "JavaScript" --limit 50
+```
+
+**Options:**
+
+| Option           | Short | Description               |
+| ---------------- | ----- | ------------------------- |
+| `--decks`        | `-d`  | List all decks            |
+| `--cards <deck>` | `-c`  | List cards in deck        |
+| `--limit <n>`    | `-l`  | Max results (default: 10) |
+
+---
+
+### `config` — Manage settings
+
+```bash
+ankiniki config               # show current config (default)
+ankiniki config --show
+ankiniki config --edit        # interactive editor
+ankiniki config --set key=value
+ankiniki config --reset       # restore defaults
+```
+
+**Configuration keys:**
+
+| Key              | Default                 | Description                            |
+| ---------------- | ----------------------- | -------------------------------------- |
+| `ankiConnectUrl` | `http://localhost:8765` | AnkiConnect API endpoint               |
+| `serverUrl`      | `http://localhost:3001` | Ankiniki backend (used for import)     |
+| `defaultDeck`    | `Default`               | Deck used when none is specified       |
+| `defaultModel`   | `Basic`                 | Card model used when none is specified |
+| `debugMode`      | `false`                 | Verbose logging                        |
+
+**Examples:**
+
+```bash
+# Show current settings and connection status
+ankiniki config --show
+
+# Set default deck
+ankiniki config --set defaultDeck=JavaScript
+
+# Change backend URL
+ankiniki config --set serverUrl=http://localhost:3001
+
+# Interactive edit (opens prompts with live deck/model selection)
+ankiniki config --edit
+
+# Reset everything to defaults
+ankiniki config --reset
+```
+
+Config is saved at `~/.ankiniki.json`.
+
+---
+
+### `import` — Bulk import from file
+
+Import multiple cards at once from CSV, JSON, or Markdown. Format is **auto-detected from the file extension**.
+
+```bash
+ankiniki import <file> [options]
+```
+
+#### CSV import
+
+```bash
+# Auto-detected from .csv extension
+ankiniki import cards.csv
+
+# Preview first (no cards created)
+ankiniki import cards.csv --preview
+
+# Override default deck and tags
+ankiniki import cards.csv --deck "JavaScript" --tags "imported,js"
+```
+
+**CSV format:**
+
+```csv
+Front,Back,Deck,Tags,Model
+"What is a closure?","A function capturing its enclosing scope","JavaScript","js,closures","Basic"
+"What is hoisting?","Moving declarations to the top","JavaScript","js","Basic"
+```
+
+Minimal (deck/tags from CLI flags):
+
+```csv
+Front,Back
+"What is a closure?","A function capturing its enclosing scope"
+```
+
+Custom column names:
+
+```bash
+ankiniki import cards.csv \
+  --mapping '{"front":"Question","back":"Answer","deck":"Subject","tags":"Topics"}'
+```
+
+---
+
+#### JSON import
+
+```bash
+# Auto-detected from .json extension
+ankiniki import cards.json
+
+ankiniki import cards.json --preview
+ankiniki import cards.json --deck "Rust" --tags "rust"
+```
+
+**JSON format (array):**
+
+```json
+[
+  {
+    "front": "What is ownership?",
+    "back": "Each value in Rust has one owner.",
+    "deck": "Rust",
+    "tags": ["rust", "memory"]
+  },
+  {
+    "front": "What is borrowing?",
+    "back": "Temporarily using a value without taking ownership.",
+    "deck": "Rust",
+    "tags": ["rust", "memory"]
+  }
+]
+```
+
+**JSON format (object with defaults):**
+
+```json
+{
+  "deck_name": "Rust",
+  "default_tags": ["rust"],
+  "default_model": "Basic",
+  "cards": [
+    { "front": "What is ownership?", "back": "Each value has one owner." },
+    { "front": "What is borrowing?", "back": "Temporarily using without owning." }
+  ]
+}
+```
+
+---
+
+#### Markdown import
+
+```bash
+# Auto-detected from .md extension
+ankiniki import cards.md
+
+ankiniki import cards.md --preview
+ankiniki import cards.md --deck "TypeScript"
+```
+
+**Markdown format:**
+
+```markdown
+---
+deck: Programming::TypeScript
+tags: [typescript, types]
+---
+
+## What is a type assertion?
+
+**Front:** What is a type assertion in TypeScript?
+**Back:** Telling the compiler to treat a value as a specific type using `as` or `<Type>`.
+
+## What is a union type?
+
+**Front:** What is a union type?
+**Back:** A type that can be one of several types, written as `A | B`.
+```
+
+- The frontmatter (`---` block) sets the default deck and tags
+- Each `##` section is one card
+- `**Front:**` and `**Back:**` are required in each section
+
+---
+
+#### Common import options
+
+| Option               | Short | Description                             |
+| -------------------- | ----- | --------------------------------------- |
+| `--format <fmt>`     | `-f`  | Force format: `csv`, `json`, `markdown` |
+| `--deck <deck>`      |       | Default deck (overrides file content)   |
+| `--model <model>`    |       | Card model (default: Basic)             |
+| `--tags <tags>`      |       | Extra tags (comma-separated)            |
+| `--preview`          | `-p`  | Dry run — show what would be imported   |
+| `--dry-run`          |       | Same as `--preview`                     |
+| `--delimiter <char>` | `-d`  | CSV delimiter (default: `,`)            |
+| `--mapping <json>`   |       | Custom CSV column mapping               |
+
+---
+
+### `import mapping` — Show format examples
+
+```bash
+ankiniki import mapping
+```
+
+---
+
+## Common Workflows
+
+### Engineer workflow: capture while coding
+
+```bash
+# Just learned something in Rust — add it immediately
+ankiniki add "Rust" \
+  "What does \`Option::unwrap_or_else\` do?" \
+  "Returns the value or calls a closure to compute a fallback"  \
+  --tags "rust,option,error-handling"
+
+# Check it was added
+ankiniki list --cards "Rust"
+```
+
+### Batch import from study notes
+
+```bash
+# Write cards in Markdown while reading docs, then import all at once
+ankiniki import study-notes.md --preview   # check first
+ankiniki import study-notes.md
+```
+
+### Daily review in terminal
+
+```bash
+# 10 random cards from your main deck
+ankiniki study "Programming" --count 10 --random
+```
+
+### Sync config on a new machine
+
+```bash
+ankiniki config --edit   # set ankiConnectUrl, serverUrl, defaultDeck
+ankiniki config --show   # verify connection is green
+```
+
+---
+
+## Troubleshooting
+
+| Problem                    | Fix                                                                           |
+| -------------------------- | ----------------------------------------------------------------------------- |
+| `Cannot connect to Anki`   | Make sure Anki desktop is open and AnkiConnect is installed                   |
+| `Deck does not exist`      | Create the deck in Anki first, or check the name spelling                     |
+| `Import failed: API Error` | Check backend server is running (`npm run dev --workspace=@ankiniki/backend`) |
+| `Model does not exist`     | Use `ankiniki list` to see model names, or use `Basic`                        |
+
+AnkiConnect status: open `http://localhost:8765` in a browser — it should return a version number.

--- a/todos.md
+++ b/todos.md
@@ -124,12 +124,16 @@
 - [ ] Add content source management
 - [ ] Create templates for different content types
 
-### 11. Enhanced CLI Features - PENDING
+### 11. Enhanced CLI Features - PARTIALLY COMPLETE
 
-- [ ] Add `ankiniki import [file-path]` command
+- [x] Add `ankiniki import <file>` command (CSV, JSON, Markdown — auto-detected)
+- [x] Add `POST /api/import/markdown` backend endpoint
+- [x] Add `POST /api/import/json/body` backend endpoint (programmatic use)
+- [ ] Add `ankiniki study --due` flag to study only Anki-scheduled due cards
+- [ ] Add `ankiniki deck create <name>` and `ankiniki deck delete <name>` commands
+- [ ] Add `ankiniki delete <noteId>` command to remove individual cards
+- [ ] Add AI generation commands (`ankiniki generate <file>`)
 - [ ] Implement batch processing for multiple files
-- [ ] Add AI generation commands
-- [ ] Create content source management
 - [ ] Add export/import of card collections
 
 ---


### PR DESCRIPTION
## Summary
Practical hands-on documentation for the CLI tool covering all commands, with real copy-paste examples. Written in both English and Japanese.

## Files Added
- ✅ `docs/user-guides/cli/README.md` — English guide
- ✅ `docs/ja/user-guides/cli/README.md` — Japanese guide
- ✅ `todos.md` — updated with completed items and 3 new todos found during writing

## Guide Contents
Both guides cover:
- Prerequisites (Anki, AnkiConnect, backend server)
- Installation / dev mode usage
- All commands with real examples: `add`, `study`, `list`, `config`, `import`
- All import formats: CSV, JSON, Markdown (with format examples)
- Common engineer workflows
- Troubleshooting table

## Missing functionality discovered while writing (added to todos)
- `ankiniki study --due` — study only Anki-scheduled due cards (currently picks any cards regardless of schedule)
- `ankiniki deck create/delete` — CLI commands for deck management
- `ankiniki delete <noteId>` — remove individual cards from CLI

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)