### PR TITLE
#8 Add deck management and card delete CLI commands

### DIFF
--- a/apps/cli/src/anki-client.ts
+++ b/apps/cli/src/anki-client.ts
@@ -66,6 +66,14 @@ export class AnkiClient {
     return this.request<number>('createDeck', { deck: name });
   }
 
+  async deleteDeck(name: string): Promise<void> {
+    return this.request<void>('deleteDecks', { decks: [name], cardsToo: true });
+  }
+
+  async deleteNotes(noteIds: number[]): Promise<void> {
+    return this.request<void>('deleteNotes', { notes: noteIds });
+  }
+
   // Note operations
   async addNote(
     deckName: string,

--- a/apps/cli/src/commands/deck.ts
+++ b/apps/cli/src/commands/deck.ts
@@ -1,0 +1,123 @@
+/**
+ * Deck command - Create, list, and delete Anki decks
+ */
+
+import { Command } from 'commander';
+import inquirer from 'inquirer';
+import chalk from 'chalk';
+import ora from 'ora';
+import { AnkiClient } from '../anki-client';
+
+export function createDeckCommand(): Command {
+  const command = new Command('deck');
+  command.description('Manage Anki decks');
+
+  // deck list
+  command
+    .command('list')
+    .description('List all decks with card counts')
+    .action(async () => {
+      const client = new AnkiClient();
+      try {
+        const spinner = ora('Connecting to Anki...').start();
+        if (!(await client.ping())) {
+          spinner.fail('Cannot connect to Anki');
+          process.exit(1);
+        }
+        spinner.succeed('Connected to Anki');
+
+        const loadSpinner = ora('Loading decks...').start();
+        const deckNames = await client.getDeckNames();
+        loadSpinner.succeed(`Found ${deckNames.length} decks`);
+
+        console.log(chalk.bold('\n📚 Available Decks:'));
+        for (const [i, name] of deckNames.entries()) {
+          const noteIds = await client.findNotes(`deck:"${name}"`);
+          console.log(
+            `${chalk.cyan(`${i + 1}.`)} ${chalk.white(name)} ${chalk.gray(`(${noteIds.length} cards)`)}`
+          );
+        }
+      } catch (error: any) {
+        console.error(chalk.red(`Error: ${error.message}`));
+        process.exit(1);
+      }
+    });
+
+  // deck create
+  command
+    .command('create <name>')
+    .description('Create a new deck')
+    .action(async (name: string) => {
+      const client = new AnkiClient();
+      try {
+        const spinner = ora('Connecting to Anki...').start();
+        if (!(await client.ping())) {
+          spinner.fail('Cannot connect to Anki');
+          process.exit(1);
+        }
+        spinner.succeed('Connected to Anki');
+
+        const createSpinner = ora(`Creating deck "${name}"...`).start();
+        await client.createDeck(name);
+        createSpinner.succeed(`Deck "${name}" created`);
+      } catch (error: any) {
+        console.error(chalk.red(`Error: ${error.message}`));
+        process.exit(1);
+      }
+    });
+
+  // deck delete
+  command
+    .command('delete <name>')
+    .description('Delete a deck and all its cards')
+    .option('--force', 'Skip confirmation prompt')
+    .action(async (name: string, options: { force?: boolean }) => {
+      const client = new AnkiClient();
+      try {
+        const spinner = ora('Connecting to Anki...').start();
+        if (!(await client.ping())) {
+          spinner.fail('Cannot connect to Anki');
+          process.exit(1);
+        }
+        spinner.succeed('Connected to Anki');
+
+        // Verify deck exists
+        const decks = await client.getDeckNames();
+        if (!decks.includes(name)) {
+          console.error(chalk.red(`Deck "${name}" not found`));
+          process.exit(1);
+        }
+
+        // Get card count to show in warning
+        const noteIds = await client.findNotes(`deck:"${name}"`);
+
+        if (!options.force) {
+          const { confirmed } = await inquirer.prompt([
+            {
+              type: 'confirm',
+              name: 'confirmed',
+              message: chalk.yellow(
+                `Delete deck "${name}" and all ${noteIds.length} cards? This cannot be undone.`
+              ),
+              default: false,
+            },
+          ]);
+          if (!confirmed) {
+            console.log(chalk.gray('Cancelled'));
+            return;
+          }
+        }
+
+        const deleteSpinner = ora(`Deleting deck "${name}"...`).start();
+        await client.deleteDeck(name);
+        deleteSpinner.succeed(
+          `Deck "${name}" deleted (${noteIds.length} cards removed)`
+        );
+      } catch (error: any) {
+        console.error(chalk.red(`Error: ${error.message}`));
+        process.exit(1);
+      }
+    });
+
+  return command;
+}

--- a/apps/cli/src/commands/delete.ts
+++ b/apps/cli/src/commands/delete.ts
@@ -1,0 +1,85 @@
+/**
+ * Delete command - Remove a flashcard by note ID
+ */
+
+import { Command } from 'commander';
+import inquirer from 'inquirer';
+import chalk from 'chalk';
+import ora from 'ora';
+import { AnkiClient } from '../anki-client';
+
+export function createDeleteCommand(): Command {
+  const command = new Command('delete');
+
+  command
+    .description('Delete a flashcard by note ID')
+    .argument('<noteId>', 'Note ID to delete (shown in ankiniki list --cards)')
+    .option('--force', 'Skip confirmation prompt')
+    .action(async (noteIdStr: string, options: { force?: boolean }) => {
+      const client = new AnkiClient();
+
+      const noteId = parseInt(noteIdStr, 10);
+      if (isNaN(noteId)) {
+        console.error(chalk.red(`Invalid note ID: "${noteIdStr}"`));
+        process.exit(1);
+      }
+
+      try {
+        const spinner = ora('Connecting to Anki...').start();
+        if (!(await client.ping())) {
+          spinner.fail('Cannot connect to Anki');
+          process.exit(1);
+        }
+        spinner.succeed('Connected to Anki');
+
+        // Fetch note info to show front/back before confirming
+        const notes = await client.notesInfo([noteId]);
+        if (!notes || notes.length === 0) {
+          console.error(chalk.red(`Note ID ${noteId} not found`));
+          process.exit(1);
+        }
+
+        const note = notes[0];
+        const fieldNames = Object.keys(note.fields);
+        const front =
+          fieldNames[0] && note.fields[fieldNames[0]]?.value
+            ? note.fields[fieldNames[0]].value
+                .replace(/<[^>]*>/g, '')
+                .substring(0, 80)
+            : '(no content)';
+
+        console.log(chalk.bold('\n🗑  Card to delete:'));
+        console.log(`   ID:    ${chalk.cyan(noteId)}`);
+        console.log(
+          `   Front: ${chalk.white(front)}${front.length >= 80 ? '...' : ''}`
+        );
+        if (note.tags?.length) {
+          console.log(`   Tags:  ${chalk.gray(note.tags.join(', '))}`);
+        }
+
+        if (!options.force) {
+          const { confirmed } = await inquirer.prompt([
+            {
+              type: 'confirm',
+              name: 'confirmed',
+              message: chalk.yellow('Delete this card? This cannot be undone.'),
+              default: false,
+            },
+          ]);
+          if (!confirmed) {
+            console.log(chalk.gray('Cancelled'));
+            return;
+          }
+        }
+
+        const deleteSpinner = ora('Deleting card...').start();
+        await client.deleteNotes([noteId]);
+        deleteSpinner.succeed(`Card ${noteId} deleted`);
+      } catch (error: any) {
+        console.error(chalk.red(`Error: ${error.message}`));
+        process.exit(1);
+      }
+    });
+
+  return command;
+}

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -7,6 +7,8 @@ import { createListCommand } from './commands/list';
 import { createConfigCommand } from './commands/config';
 import { createStudyCommand } from './commands/study';
 import { importCommand } from './commands/import';
+import { createDeckCommand } from './commands/deck';
+import { createDeleteCommand } from './commands/delete';
 import { APP_CONFIG } from '@ankiniki/shared';
 
 const program = new Command();
@@ -22,6 +24,8 @@ program.addCommand(createListCommand());
 program.addCommand(createStudyCommand());
 program.addCommand(createConfigCommand());
 program.addCommand(importCommand);
+program.addCommand(createDeckCommand());
+program.addCommand(createDeleteCommand());
 
 // Global error handling
 process.on('unhandledRejection', error => {

--- a/todos.md
+++ b/todos.md
@@ -130,8 +130,8 @@
 - [x] Add `POST /api/import/markdown` backend endpoint
 - [x] Add `POST /api/import/json/body` backend endpoint (programmatic use)
 - [ ] Add `ankiniki study --due` flag to study only Anki-scheduled due cards
-- [ ] Add `ankiniki deck create <name>` and `ankiniki deck delete <name>` commands
-- [ ] Add `ankiniki delete <noteId>` command to remove individual cards
+- [x] Add `ankiniki deck create <name>` and `ankiniki deck delete <name>` commands
+- [x] Add `ankiniki delete <noteId>` command to remove individual cards
 - [ ] Add AI generation commands (`ankiniki generate <file>`)
 - [ ] Implement batch processing for multiple files
 - [ ] Add export/import of card collections


### PR DESCRIPTION
## Summary
Two missing CLI commands discovered while writing the hands-on guide, now implemented.

## New Commands

### `ankiniki deck` — Deck management
```bash
ankiniki deck list                  # list all decks with card counts
ankiniki deck create "My Deck"      # create a new deck
ankiniki deck delete "My Deck"      # delete with confirmation prompt
ankiniki deck delete "My Deck" --force  # skip confirmation
```

### `ankiniki delete <noteId>` — Remove a card
```bash
ankiniki delete 1234567890          # shows card preview + confirmation
ankiniki delete 1234567890 --force  # skip confirmation
```
Note IDs are shown by `ankiniki list --cards <deck>`.

## Changes
- ✅ `apps/cli/src/commands/deck.ts` — new deck subcommand (list / create / delete)
- ✅ `apps/cli/src/commands/delete.ts` — new delete command with note preview
- ✅ `apps/cli/src/anki-client.ts` — add `deleteDeck()` and `deleteNotes()` methods
- ✅ `apps/cli/src/index.ts` — register both new commands
- ✅ `todos.md` — mark items as completed

## Safety
Both destructive operations (deck delete, card delete) show a confirmation prompt by default and require explicit `--force` to skip it.

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)