### PR TITLE
#34 Remove dead utility exports from packages/shared

### DIFF
--- a/apps/cli/src/commands/study.ts
+++ b/apps/cli/src/commands/study.ts
@@ -2,6 +2,7 @@ import { Command } from 'commander';
 import inquirer from 'inquirer';
 import chalk from 'chalk';
 import ora from 'ora';
+import { shuffleArray } from '@ankiniki/shared';
 import { AnkiClient } from '../anki-client';
 
 export function createStudyCommand(): Command {
@@ -156,13 +157,4 @@ function formatText(text: string): string {
   // Simple formatting for terminal
   const lines = text.split('\n');
   return lines.map(line => `   ${line}`).join('\n');
-}
-
-function shuffleArray<T>(array: T[]): T[] {
-  const shuffled = [...array];
-  for (let i = shuffled.length - 1; i > 0; i--) {
-    const j = Math.floor(Math.random() * (i + 1));
-    [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
-  }
-  return shuffled;
 }

--- a/packages/shared/src/__tests__/utils.test.ts
+++ b/packages/shared/src/__tests__/utils.test.ts
@@ -1,15 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import {
-  generateId,
-  formatDate,
-  parseDate,
-  sanitizeCardContent,
-  extractCodeFromMarkdown,
-  isValidDeckName,
-  isValidCardContent,
-  shuffleArray,
-  retry,
-} from '../utils';
+import { generateId, sanitizeCardContent, shuffleArray, retry } from '../utils';
 
 describe('generateId', () => {
   it('returns a non-empty string', () => {
@@ -20,24 +10,6 @@ describe('generateId', () => {
   it('generates unique ids', () => {
     const ids = new Set(Array.from({ length: 100 }, generateId));
     expect(ids.size).toBe(100);
-  });
-});
-
-describe('formatDate', () => {
-  it('formats a date as YYYY-MM-DD', () => {
-    expect(formatDate(new Date('2024-01-15T12:00:00Z'))).toBe('2024-01-15');
-  });
-});
-
-describe('parseDate', () => {
-  it('parses a valid date string', () => {
-    const d = parseDate('2024-01-15');
-    expect(d).toBeInstanceOf(Date);
-    expect(d.getFullYear()).toBe(2024);
-  });
-
-  it('throws AnkinikiError for invalid date', () => {
-    expect(() => parseDate('not-a-date')).toThrow('Invalid date format');
   });
 });
 
@@ -58,65 +30,6 @@ describe('sanitizeCardContent', () => {
 
   it('leaves safe content unchanged', () => {
     expect(sanitizeCardContent('What is 2 + 2?')).toBe('What is 2 + 2?');
-  });
-});
-
-describe('extractCodeFromMarkdown', () => {
-  it('extracts code blocks', () => {
-    const md = 'Text\n```js\nconsole.log("hi");\n```\nMore text';
-    const blocks = extractCodeFromMarkdown(md);
-    expect(blocks).toHaveLength(1);
-    expect(blocks[0]).toContain('console.log');
-  });
-
-  it('returns empty array when no code blocks', () => {
-    expect(extractCodeFromMarkdown('No code here')).toEqual([]);
-  });
-
-  it('handles multiple code blocks', () => {
-    const md = '```\nfoo\n```\n```\nbar\n```';
-    expect(extractCodeFromMarkdown(md)).toHaveLength(2);
-  });
-});
-
-describe('isValidDeckName', () => {
-  it('accepts alphanumeric names', () => {
-    expect(isValidDeckName('MyDeck123')).toBe(true);
-  });
-
-  it('accepts names with spaces, hyphens, underscores', () => {
-    expect(isValidDeckName('My Deck-1_2')).toBe(true);
-  });
-
-  it('rejects empty string', () => {
-    expect(isValidDeckName('')).toBe(false);
-  });
-
-  it('rejects names longer than 100 characters', () => {
-    expect(isValidDeckName('a'.repeat(101))).toBe(false);
-  });
-
-  it('rejects special characters', () => {
-    expect(isValidDeckName('Deck!')).toBe(false);
-    expect(isValidDeckName('Deck/Sub')).toBe(false);
-  });
-});
-
-describe('isValidCardContent', () => {
-  it('accepts non-empty content within limit', () => {
-    expect(isValidCardContent('What is 2+2?')).toBe(true);
-  });
-
-  it('rejects empty string', () => {
-    expect(isValidCardContent('')).toBe(false);
-  });
-
-  it('rejects content over 10000 characters', () => {
-    expect(isValidCardContent('a'.repeat(10001))).toBe(false);
-  });
-
-  it('accepts content of exactly 10000 characters', () => {
-    expect(isValidCardContent('a'.repeat(10000))).toBe(true);
   });
 });
 

--- a/packages/shared/src/anki-client.ts
+++ b/packages/shared/src/anki-client.ts
@@ -5,6 +5,14 @@ import {
   ANKI_CONNECT,
 } from './index';
 
+export interface NoteInfo {
+  noteId: number;
+  modelName: string;
+  tags: string[];
+  fields: Record<string, { value: string; order: number }>;
+  cards: number[];
+}
+
 export interface AnkiConnectClientOptions {
   baseURL?: string;
   timeout?: number;
@@ -148,8 +156,8 @@ export class AnkiConnectClient {
     return this.request<number[]>('findNotes', { query });
   }
 
-  async notesInfo(noteIds: number[]): Promise<unknown[]> {
-    return this.request<unknown[]>('notesInfo', { notes: noteIds });
+  async notesInfo(noteIds: number[]): Promise<NoteInfo[]> {
+    return this.request<NoteInfo[]>('notesInfo', { notes: noteIds });
   }
 
   // Model operations

--- a/packages/shared/src/utils.ts
+++ b/packages/shared/src/utils.ts
@@ -1,21 +1,6 @@
-import { AnkinikiError } from './types';
-
 // ID generation
 export function generateId(): string {
   return Math.random().toString(36).substring(2, 15) + Date.now().toString(36);
-}
-
-// Date utilities
-export function formatDate(date: Date): string {
-  return date.toISOString().split('T')[0];
-}
-
-export function parseDate(dateString: string): Date {
-  const date = new Date(dateString);
-  if (isNaN(date.getTime())) {
-    throw new AnkinikiError('Invalid date format', 'INVALID_DATE', 400);
-  }
-  return date;
 }
 
 // Card utilities
@@ -26,23 +11,6 @@ export function sanitizeCardContent(content: string): string {
     .trim();
 }
 
-export function extractCodeFromMarkdown(markdown: string): string[] {
-  const codeBlockRegex = /```[\s\S]*?```/g;
-  const matches = markdown.match(codeBlockRegex) || [];
-  return matches.map(match =>
-    match.replace(/```(\w+)?\n?/, '').replace(/```$/, '')
-  );
-}
-
-// Validation helpers
-export function isValidDeckName(name: string): boolean {
-  return /^[a-zA-Z0-9\s\-_]{1,100}$/.test(name);
-}
-
-export function isValidCardContent(content: string): boolean {
-  return content.length > 0 && content.length <= 10000;
-}
-
 // Array utilities
 export function shuffleArray<T>(array: T[]): T[] {
   const shuffled = [...array];
@@ -51,18 +19,6 @@ export function shuffleArray<T>(array: T[]): T[] {
     [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
   }
   return shuffled;
-}
-
-// Debounce utility
-export function debounce<T extends (...args: any[]) => any>(
-  func: T,
-  wait: number
-): (...args: Parameters<T>) => void {
-  let timeout: NodeJS.Timeout;
-  return function (this: any, ...args: Parameters<T>) {
-    clearTimeout(timeout);
-    timeout = setTimeout(() => func.apply(this, args), wait);
-  };
 }
 
 // Async retry utility
@@ -88,13 +44,4 @@ export async function retry<T>(
   throw new Error(
     `Failed after ${maxAttempts} attempts: ${lastError?.message || 'Unknown error'}`
   );
-}
-
-// Environment utilities
-export function isDevelopment(): boolean {
-  return process.env.NODE_ENV === 'development';
-}
-
-export function isProduction(): boolean {
-  return process.env.NODE_ENV === 'production';
 }


### PR DESCRIPTION
## Summary

- Remove 8 unused exported functions from `packages/shared/src/utils.ts`: `formatDate`, `parseDate`, `extractCodeFromMarkdown`, `isValidDeckName`, `isValidCardContent`, `debounce`, `isDevelopment`, `isProduction`
- CLI `study.ts` now imports `shuffleArray` from `@ankiniki/shared` instead of a local copy
- Add `NoteInfo` type to the shared `AnkiConnectClient`; `notesInfo()` now returns `NoteInfo[]` instead of `unknown[]` — fixes TS errors that surfaced from the stricter typing

## Test plan
- [x] `npm run build -w @ankiniki/shared` passes
- [x] `tsc --noEmit` on `apps/cli` passes
- [x] 60 tests passing

Closes #34
Part of #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)