### PR TITLE
#39 RFC 7807 Problem Details error responses

### DIFF
--- a/packages/backend/src/middleware/errorHandler.ts
+++ b/packages/backend/src/middleware/errorHandler.ts
@@ -1,11 +1,17 @@
 import { Request, Response, NextFunction } from 'express';
-import { AnkinikiError, ApiResponse } from '@ankiniki/shared';
+import { AnkinikiError } from '@ankiniki/shared';
 import { logger } from '../utils/logger';
+import { sendProblem, PROBLEM_TYPES } from '../utils/response';
+
+const ERROR_CODE_TO_PROBLEM_TYPE: Record<string, string> = {
+  VALIDATION_ERROR: PROBLEM_TYPES.VALIDATION,
+  ANKI_CONNECT_ERROR: PROBLEM_TYPES.ANKI_CONNECT,
+};
 
 export function errorHandler(
   error: Error,
   req: Request,
-  res: Response<ApiResponse>,
+  res: Response,
   _next: NextFunction
 ) {
   logger.error('Request error', {
@@ -16,29 +22,27 @@ export function errorHandler(
   });
 
   if (error instanceof AnkinikiError) {
-    return res.status(error.statusCode).json({
-      success: false,
-      error: error.message,
-      message: error.message,
+    const type =
+      ERROR_CODE_TO_PROBLEM_TYPE[error.code] ?? PROBLEM_TYPES.INTERNAL;
+    return sendProblem(res, error.statusCode, error.message, {
+      type,
+      instance: req.path,
     });
   }
 
-  // Default error response
-  res.status(500).json({
-    success: false,
-    error: 'Internal Server Error',
-    message: 'An unexpected error occurred',
+  sendProblem(res, 500, 'An unexpected error occurred', {
+    type: PROBLEM_TYPES.INTERNAL,
+    instance: req.path,
   });
 }
 
 export function notFoundHandler(
   req: Request,
-  res: Response<ApiResponse>,
+  res: Response,
   _next: NextFunction
 ) {
-  res.status(404).json({
-    success: false,
-    error: 'Not Found',
-    message: `Route ${req.method} ${req.path} not found`,
+  sendProblem(res, 404, `Route ${req.method} ${req.path} not found`, {
+    type: PROBLEM_TYPES.NOT_FOUND,
+    instance: req.path,
   });
 }

--- a/packages/backend/src/routes/export.ts
+++ b/packages/backend/src/routes/export.ts
@@ -8,7 +8,7 @@ import os from 'os';
 import path from 'path';
 import { ankiConnect } from '../services/ankiConnect';
 import { logger } from '../utils/logger';
-import { fail } from '../utils/response';
+import { sendProblem, PROBLEM_TYPES } from '../utils/response';
 
 const router = Router();
 
@@ -33,7 +33,10 @@ router.get('/deck/:name', async (req: Request, res: Response) => {
     // Verify deck exists
     const decks = await ankiConnect.getDeckNames();
     if (!decks.includes(deckName)) {
-      return res.status(404).json(fail(`Deck "${deckName}" not found`));
+      return sendProblem(res, 404, `Deck "${deckName}" not found`, {
+        type: PROBLEM_TYPES.NOT_FOUND,
+        instance: req.path,
+      });
     }
 
     logger.info('Exporting deck', { deckName, includeSched, tmpFile });
@@ -44,13 +47,17 @@ router.get('/deck/:name', async (req: Request, res: Response) => {
       includeSched
     );
     if (!exported) {
-      return res
-        .status(500)
-        .json(fail('AnkiConnect failed to export the deck'));
+      return sendProblem(res, 500, 'AnkiConnect failed to export the deck', {
+        type: PROBLEM_TYPES.ANKI_CONNECT,
+        instance: req.path,
+      });
     }
 
     if (!fs.existsSync(tmpFile)) {
-      return res.status(500).json(fail('Export file was not created'));
+      return sendProblem(res, 500, 'Export file was not created', {
+        type: PROBLEM_TYPES.INTERNAL,
+        instance: req.path,
+      });
     }
 
     const stat = fs.statSync(tmpFile);
@@ -84,17 +91,21 @@ router.get('/deck/:name', async (req: Request, res: Response) => {
       logger.error('Error streaming export file', err);
       fs.unlink(tmpFile, () => {});
       if (!res.headersSent) {
-        res.status(500).json(fail('Failed to stream file'));
+        sendProblem(res, 500, 'Failed to stream file', {
+          type: PROBLEM_TYPES.INTERNAL,
+          instance: req.path,
+        });
       }
     });
   } catch (error) {
     fs.unlink(tmpFile, () => {});
     logger.error('Deck export error', error);
-    res
-      .status(500)
-      .json(
-        fail(error instanceof Error ? error.message : 'Internal server error')
-      );
+    sendProblem(
+      res,
+      500,
+      error instanceof Error ? error.message : 'Internal server error',
+      { type: PROBLEM_TYPES.INTERNAL, instance: req.path }
+    );
   }
 });
 

--- a/packages/backend/src/routes/health.ts
+++ b/packages/backend/src/routes/health.ts
@@ -1,8 +1,7 @@
-import { Router, Response } from 'express';
-import { ApiResponse } from '@ankiniki/shared';
+import { Router } from 'express';
 import { ankiConnect } from '../services/ankiConnect';
 import { config } from '../config';
-import { ok, fail } from '../utils/response';
+import { ok, sendProblem, PROBLEM_TYPES } from '../utils/response';
 
 const router = Router();
 
@@ -16,7 +15,7 @@ interface HealthStatus {
   };
 }
 
-router.get('/', async (req, res: Response<ApiResponse<HealthStatus>>) => {
+router.get('/', async (req, res) => {
   const ankiConnected = await ankiConnect.ping();
 
   const healthData: HealthStatus = {
@@ -32,7 +31,11 @@ router.get('/', async (req, res: Response<ApiResponse<HealthStatus>>) => {
   if (ankiConnected) {
     res.status(200).json(ok(healthData, 'All services are healthy'));
   } else {
-    res.status(503).json(fail('AnkiConnect is not available', healthData));
+    sendProblem(res, 503, 'AnkiConnect is not available', {
+      type: PROBLEM_TYPES.ANKI_CONNECT,
+      instance: req.path,
+      ankiConnect: healthData.ankiConnect,
+    });
   }
 });
 

--- a/packages/backend/src/routes/import.ts
+++ b/packages/backend/src/routes/import.ts
@@ -24,7 +24,7 @@ import {
 } from '@ankiniki/shared';
 import { ankiConnect } from '../services/ankiConnect';
 import { logger } from '../utils/logger';
-import { ok, fail } from '../utils/response';
+import { ok, sendProblem, PROBLEM_TYPES } from '../utils/response';
 
 // Extend Request interface for multer
 interface MulterRequest extends Request {
@@ -125,7 +125,9 @@ router.post(
   async (req: MulterRequest, res: Response) => {
     try {
       if (!req.file) {
-        return res.status(400).json(fail('No CSV file uploaded'));
+        return sendProblem(res, 400, 'No CSV file uploaded', {
+          type: PROBLEM_TYPES.VALIDATION,
+        });
       }
 
       // Parse options from form data
@@ -134,7 +136,9 @@ router.post(
         try {
           options = JSON.parse(req.body.options);
         } catch (error) {
-          return res.status(400).json(fail('Invalid options JSON format'));
+          return sendProblem(res, 400, 'Invalid options JSON format', {
+            type: PROBLEM_TYPES.VALIDATION,
+          });
         }
       }
 
@@ -264,17 +268,19 @@ router.post(
       );
     } catch (error) {
       if (error instanceof z.ZodError) {
-        return res
-          .status(400)
-          .json(fail('Invalid import options', error.errors));
+        return sendProblem(res, 400, 'Invalid import options', {
+          type: PROBLEM_TYPES.VALIDATION,
+          errors: error.errors,
+        });
       }
 
       logger.error('CSV import error:', error);
-      res
-        .status(500)
-        .json(
-          fail(error instanceof Error ? error.message : 'Internal server error')
-        );
+      sendProblem(
+        res,
+        500,
+        error instanceof Error ? error.message : 'Internal server error',
+        { type: PROBLEM_TYPES.INTERNAL }
+      );
     }
   }
 );
@@ -308,7 +314,9 @@ router.post(
   async (req: MulterRequest, res: Response) => {
     try {
       if (!req.file) {
-        return res.status(400).json(fail('No CSV file uploaded'));
+        return sendProblem(res, 400, 'No CSV file uploaded', {
+          type: PROBLEM_TYPES.VALIDATION,
+        });
       }
 
       // Parse options with dryRun forced to true
@@ -320,7 +328,9 @@ router.post(
           const parsed = JSON.parse(req.body.options);
           options = { ...parsed, dryRun: true };
         } catch (error) {
-          return res.status(400).json(fail('Invalid options JSON format'));
+          return sendProblem(res, 400, 'Invalid options JSON format', {
+            type: PROBLEM_TYPES.VALIDATION,
+          });
         }
       }
 
@@ -349,11 +359,12 @@ router.post(
       );
     } catch (error) {
       logger.error('CSV preview error:', error);
-      res
-        .status(500)
-        .json(
-          fail(error instanceof Error ? error.message : 'Internal server error')
-        );
+      sendProblem(
+        res,
+        500,
+        error instanceof Error ? error.message : 'Internal server error',
+        { type: PROBLEM_TYPES.INTERNAL }
+      );
     }
   }
 );
@@ -387,7 +398,9 @@ router.post(
   async (req: MulterRequest, res: Response) => {
     try {
       if (!req.file) {
-        return res.status(400).json(fail('No JSON file uploaded'));
+        return sendProblem(res, 400, 'No JSON file uploaded', {
+          type: PROBLEM_TYPES.VALIDATION,
+        });
       }
 
       // Parse options from form data
@@ -396,7 +409,9 @@ router.post(
         try {
           options = JSON.parse(req.body.options);
         } catch (error) {
-          return res.status(400).json(fail('Invalid options JSON format'));
+          return sendProblem(res, 400, 'Invalid options JSON format', {
+            type: PROBLEM_TYPES.VALIDATION,
+          });
         }
       }
 
@@ -415,9 +430,9 @@ router.post(
         const jsonContent = req.file.buffer.toString('utf-8');
         jsonData = JSON.parse(jsonContent);
       } catch (error) {
-        return res
-          .status(400)
-          .json(fail('Invalid JSON format in uploaded file'));
+        return sendProblem(res, 400, 'Invalid JSON format in uploaded file', {
+          type: PROBLEM_TYPES.VALIDATION,
+        });
       }
 
       // Process JSON into cards
@@ -532,21 +547,21 @@ router.post(
       );
     } catch (error) {
       if (error instanceof z.ZodError) {
-        return res
-          .status(400)
-          .json(fail('Invalid import options', error.errors));
+        return sendProblem(res, 400, 'Invalid import options', {
+          type: PROBLEM_TYPES.VALIDATION,
+          errors: error.errors,
+        });
       }
 
       logger.error('JSON import error:', error);
-      res
-        .status(500)
-        .json(
-          fail(
-            error instanceof Error
-              ? error.message
-              : String(error) || 'Internal server error'
-          )
-        );
+      sendProblem(
+        res,
+        500,
+        error instanceof Error
+          ? error.message
+          : String(error) || 'Internal server error',
+        { type: PROBLEM_TYPES.INTERNAL }
+      );
     }
   }
 );
@@ -580,7 +595,9 @@ router.post(
   async (req: MulterRequest, res: Response) => {
     try {
       if (!req.file) {
-        return res.status(400).json(fail('No JSON file uploaded'));
+        return sendProblem(res, 400, 'No JSON file uploaded', {
+          type: PROBLEM_TYPES.VALIDATION,
+        });
       }
 
       // Parse options with dryRun forced to true
@@ -592,7 +609,9 @@ router.post(
           const parsed = JSON.parse(req.body.options);
           options = { ...parsed, dryRun: true };
         } catch (error) {
-          return res.status(400).json(fail('Invalid options JSON format'));
+          return sendProblem(res, 400, 'Invalid options JSON format', {
+            type: PROBLEM_TYPES.VALIDATION,
+          });
         }
       }
 
@@ -604,9 +623,9 @@ router.post(
         const jsonContent = req.file.buffer.toString('utf-8');
         jsonData = JSON.parse(jsonContent);
       } catch (error) {
-        return res
-          .status(400)
-          .json(fail('Invalid JSON format in uploaded file'));
+        return sendProblem(res, 400, 'Invalid JSON format in uploaded file', {
+          type: PROBLEM_TYPES.VALIDATION,
+        });
       }
 
       // Process and validate
@@ -644,11 +663,12 @@ router.post(
       );
     } catch (error) {
       logger.error('JSON preview error:', error);
-      res
-        .status(500)
-        .json(
-          fail(error instanceof Error ? error.message : 'Internal server error')
-        );
+      sendProblem(
+        res,
+        500,
+        error instanceof Error ? error.message : 'Internal server error',
+        { type: PROBLEM_TYPES.INTERNAL }
+      );
     }
   }
 );
@@ -661,7 +681,9 @@ router.post(
   async (req: MulterRequest, res: Response) => {
     try {
       if (!req.file) {
-        return res.status(400).json(fail('No file uploaded'));
+        return sendProblem(res, 400, 'No file uploaded', {
+          type: PROBLEM_TYPES.VALIDATION,
+        });
       }
 
       let options: Partial<z.infer<typeof MarkdownImportOptionsSchema>> = {};
@@ -669,7 +691,9 @@ router.post(
         try {
           options = JSON.parse(req.body.options);
         } catch {
-          return res.status(400).json(fail('Invalid options JSON format'));
+          return sendProblem(res, 400, 'Invalid options JSON format', {
+            type: PROBLEM_TYPES.VALIDATION,
+          });
         }
       }
       const validatedOptions = MarkdownImportOptionsSchema.parse(options);
@@ -763,16 +787,18 @@ router.post(
       );
     } catch (error) {
       if (error instanceof z.ZodError) {
-        return res
-          .status(400)
-          .json(fail('Invalid import options', error.errors));
+        return sendProblem(res, 400, 'Invalid import options', {
+          type: PROBLEM_TYPES.VALIDATION,
+          errors: error.errors,
+        });
       }
       logger.error('Markdown import error:', error);
-      res
-        .status(500)
-        .json(
-          fail(error instanceof Error ? error.message : 'Internal server error')
-        );
+      sendProblem(
+        res,
+        500,
+        error instanceof Error ? error.message : 'Internal server error',
+        { type: PROBLEM_TYPES.INTERNAL }
+      );
     }
   }
 );
@@ -783,7 +809,9 @@ router.post(
   async (req: MulterRequest, res: Response) => {
     try {
       if (!req.file) {
-        return res.status(400).json(fail('No file uploaded'));
+        return sendProblem(res, 400, 'No file uploaded', {
+          type: PROBLEM_TYPES.VALIDATION,
+        });
       }
 
       let options: Partial<z.infer<typeof MarkdownImportOptionsSchema>> = {
@@ -793,7 +821,9 @@ router.post(
         try {
           options = { ...JSON.parse(req.body.options), dryRun: true };
         } catch {
-          return res.status(400).json(fail('Invalid options JSON format'));
+          return sendProblem(res, 400, 'Invalid options JSON format', {
+            type: PROBLEM_TYPES.VALIDATION,
+          });
         }
       }
       const validatedOptions = MarkdownImportOptionsSchema.parse(options);
@@ -815,11 +845,12 @@ router.post(
       );
     } catch (error) {
       logger.error('Markdown preview error:', error);
-      res
-        .status(500)
-        .json(
-          fail(error instanceof Error ? error.message : 'Internal server error')
-        );
+      sendProblem(
+        res,
+        500,
+        error instanceof Error ? error.message : 'Internal server error',
+        { type: PROBLEM_TYPES.INTERNAL }
+      );
     }
   }
 );
@@ -834,9 +865,9 @@ router.post('/json/body', async (req: Request, res: Response) => {
     };
 
     if (!cards) {
-      return res
-        .status(400)
-        .json(fail('Missing "cards" field in request body'));
+      return sendProblem(res, 400, 'Missing "cards" field in request body', {
+        type: PROBLEM_TYPES.VALIDATION,
+      });
     }
 
     const validatedOptions = JsonImportOptionsSchema.parse(rawOptions ?? {});
@@ -933,14 +964,18 @@ router.post('/json/body', async (req: Request, res: Response) => {
     );
   } catch (error) {
     if (error instanceof z.ZodError) {
-      return res.status(400).json(fail('Invalid import options', error.errors));
+      return sendProblem(res, 400, 'Invalid import options', {
+        type: PROBLEM_TYPES.VALIDATION,
+        errors: error.errors,
+      });
     }
     logger.error('JSON body import error:', error);
-    res
-      .status(500)
-      .json(
-        fail(error instanceof Error ? error.message : 'Internal server error')
-      );
+    sendProblem(
+      res,
+      500,
+      error instanceof Error ? error.message : 'Internal server error',
+      { type: PROBLEM_TYPES.INTERNAL }
+    );
   }
 });
 

--- a/packages/backend/src/routes/ml.ts
+++ b/packages/backend/src/routes/ml.ts
@@ -7,7 +7,7 @@ import multer from 'multer';
 import { z } from 'zod';
 import { logger } from '../utils/logger';
 import mlService from '../services/mlService';
-import { ok, fail } from '../utils/response';
+import { ok, sendProblem, PROBLEM_TYPES } from '../utils/response';
 
 const router = Router();
 
@@ -110,7 +110,9 @@ router.get('/health', async (req: Request, res: Response) => {
     );
   } catch (error) {
     logger.error('Error checking ML service health:', error);
-    res.status(500).json(fail('Failed to check ML service health'));
+    sendProblem(res, 500, 'Failed to check ML service health', {
+      type: PROBLEM_TYPES.INTERNAL,
+    });
   }
 });
 
@@ -159,15 +161,22 @@ router.post('/generate/cards', async (req: Request, res: Response) => {
     if (result.success) {
       res.json(ok(result));
     } else {
-      res.status(500).json(fail(result.error || 'Failed to generate cards'));
+      sendProblem(res, 500, result.error || 'Failed to generate cards', {
+        type: PROBLEM_TYPES.INTERNAL,
+      });
     }
   } catch (error) {
     if (error instanceof z.ZodError) {
-      return res.status(400).json(fail('Invalid request data', error.errors));
+      return sendProblem(res, 400, 'Invalid request data', {
+        type: PROBLEM_TYPES.VALIDATION,
+        errors: error.errors,
+      });
     }
 
     logger.error('Error generating cards:', error);
-    res.status(500).json(fail('Internal server error'));
+    sendProblem(res, 500, 'Internal server error', {
+      type: PROBLEM_TYPES.INTERNAL,
+    });
   }
 });
 
@@ -209,15 +218,22 @@ router.post('/process/content', async (req: Request, res: Response) => {
     if (result.success) {
       res.json(ok(result));
     } else {
-      res.status(500).json(fail(result.error || 'Failed to process content'));
+      sendProblem(res, 500, result.error || 'Failed to process content', {
+        type: PROBLEM_TYPES.INTERNAL,
+      });
     }
   } catch (error) {
     if (error instanceof z.ZodError) {
-      return res.status(400).json(fail('Invalid request data', error.errors));
+      return sendProblem(res, 400, 'Invalid request data', {
+        type: PROBLEM_TYPES.VALIDATION,
+        errors: error.errors,
+      });
     }
 
     logger.error('Error processing content:', error);
-    res.status(500).json(fail('Internal server error'));
+    sendProblem(res, 500, 'Internal server error', {
+      type: PROBLEM_TYPES.INTERNAL,
+    });
   }
 });
 
@@ -247,7 +263,9 @@ router.post(
   async (req: Request, res: Response) => {
     try {
       if (!req.file) {
-        return res.status(400).json(fail('No file uploaded'));
+        return sendProblem(res, 400, 'No file uploaded', {
+          type: PROBLEM_TYPES.VALIDATION,
+        });
       }
 
       const { buffer, originalname, mimetype } = req.file;
@@ -267,19 +285,19 @@ router.post(
       if (result.success) {
         res.json(ok({ ...result, filename: originalname }));
       } else {
-        res.status(500).json(
-          fail(result.error || 'Failed to process file', {
-            filename: originalname,
-          })
-        );
+        sendProblem(res, 500, result.error || 'Failed to process file', {
+          type: PROBLEM_TYPES.INTERNAL,
+          filename: originalname,
+        });
       }
     } catch (error) {
       logger.error('Error processing file:', error);
-      res
-        .status(500)
-        .json(
-          fail(error instanceof Error ? error.message : 'Internal server error')
-        );
+      sendProblem(
+        res,
+        500,
+        error instanceof Error ? error.message : 'Internal server error',
+        { type: PROBLEM_TYPES.INTERNAL }
+      );
     }
   }
 );
@@ -324,15 +342,22 @@ router.post('/enhance/question', async (req: Request, res: Response) => {
     if (result.success) {
       res.json(ok(result));
     } else {
-      res.status(500).json(fail(result.error || 'Failed to enhance question'));
+      sendProblem(res, 500, result.error || 'Failed to enhance question', {
+        type: PROBLEM_TYPES.INTERNAL,
+      });
     }
   } catch (error) {
     if (error instanceof z.ZodError) {
-      return res.status(400).json(fail('Invalid request data', error.errors));
+      return sendProblem(res, 400, 'Invalid request data', {
+        type: PROBLEM_TYPES.VALIDATION,
+        errors: error.errors,
+      });
     }
 
     logger.error('Error enhancing question:', error);
-    res.status(500).json(fail('Internal server error'));
+    sendProblem(res, 500, 'Internal server error', {
+      type: PROBLEM_TYPES.INTERNAL,
+    });
   }
 });
 
@@ -353,7 +378,9 @@ router.get('/models', async (req: Request, res: Response) => {
     res.json(ok(models));
   } catch (error) {
     logger.error('Error getting available models:', error);
-    res.status(500).json(fail('Failed to get available models'));
+    sendProblem(res, 500, 'Failed to get available models', {
+      type: PROBLEM_TYPES.INTERNAL,
+    });
   }
 });
 

--- a/packages/backend/src/utils/response.ts
+++ b/packages/backend/src/utils/response.ts
@@ -1,9 +1,13 @@
 /**
  * Response shape helpers — enforces a consistent API contract across all routes.
  *
- * Success: { success: true,  data: T,      message?: string  }
- * Error:   { success: false, error: string, details?: unknown }
+ * Success: { success: true, data: T, message?: string }
+ * Error:   RFC 7807 Problem Details (application/problem+json)
+ *           { type, title, status, detail, instance? }
  */
+
+import { Response } from 'express';
+import { ProblemDetails } from '@ankiniki/shared';
 
 export function ok<T>(data: T, message?: string) {
   return {
@@ -13,10 +17,71 @@ export function ok<T>(data: T, message?: string) {
   };
 }
 
-export function fail(error: string, details?: unknown) {
-  return {
-    success: false as const,
-    error,
-    ...(details !== undefined ? { details } : {}),
-  };
+// ─── RFC 7807 Problem Details ─────────────────────────────────────────────────
+
+export const PROBLEM_TYPES = {
+  VALIDATION: '/problems/validation-error',
+  NOT_FOUND: '/problems/not-found',
+  CONFLICT: '/problems/conflict',
+  ANKI_CONNECT: '/problems/anki-connect-unavailable',
+  INTERNAL: '/problems/internal-error',
+} as const;
+
+const PROBLEM_TITLES: Record<string, string> = {
+  [PROBLEM_TYPES.VALIDATION]: 'Validation Error',
+  [PROBLEM_TYPES.NOT_FOUND]: 'Not Found',
+  [PROBLEM_TYPES.CONFLICT]: 'Conflict',
+  [PROBLEM_TYPES.ANKI_CONNECT]: 'AnkiConnect Unavailable',
+  [PROBLEM_TYPES.INTERNAL]: 'Internal Server Error',
+};
+
+const STATUS_TITLES: Record<number, string> = {
+  400: 'Bad Request',
+  401: 'Unauthorized',
+  403: 'Forbidden',
+  404: 'Not Found',
+  409: 'Conflict',
+  500: 'Internal Server Error',
+  502: 'Bad Gateway',
+  503: 'Service Unavailable',
+};
+
+/**
+ * Send an RFC 7807 Problem Details response.
+ * Sets Content-Type to application/problem+json automatically.
+ *
+ * @param res     Express Response
+ * @param status  HTTP status code
+ * @param detail  Human-readable explanation specific to this occurrence
+ * @param opts    Optional: type URI, title override, instance URI, and any
+ *                RFC 7807 extension members (spread into the body)
+ */
+export function sendProblem(
+  res: Response,
+  status: number,
+  detail: string,
+  opts?: {
+    type?: string;
+    title?: string;
+    instance?: string;
+    [key: string]: unknown;
+  }
+): void {
+  const {
+    type: optType,
+    title: optTitle,
+    instance,
+    ...extensions
+  } = opts ?? {};
+  const type = optType ?? 'about:blank';
+  const title =
+    optTitle ?? PROBLEM_TITLES[type] ?? STATUS_TITLES[status] ?? 'Error';
+
+  const body: ProblemDetails = { type, title, status, detail };
+  if (instance) {
+    body.instance = instance;
+  }
+  Object.assign(body, extensions);
+
+  res.status(status).type('application/problem+json').json(body);
 }

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -52,16 +52,25 @@ export const AnkiConnectResponseSchema = z.object({
 export type AnkiConnectResponse = z.infer<typeof AnkiConnectResponseSchema>;
 
 // API Response types
-export const ApiResponseSchema = z.object({
-  success: z.boolean(),
-  data: z.any().optional(),
-  error: z.string().optional(),
-  message: z.string().optional(),
-});
 
-export type ApiResponse<T = any> = z.infer<typeof ApiResponseSchema> & {
-  data?: T;
-};
+/** RFC 7807 Problem Details for HTTP APIs */
+export interface ProblemDetails {
+  type: string;
+  title: string;
+  status: number;
+  detail: string;
+  instance?: string;
+  [key: string]: unknown;
+}
+
+export interface OkResponse<T = unknown> {
+  success: true;
+  data: T;
+  message?: string;
+}
+
+/** Discriminated union: success carries data, error carries Problem Details */
+export type ApiResponse<T = unknown> = OkResponse<T> | ProblemDetails;
 
 // Configuration types
 export const ConfigSchema = z.object({


### PR DESCRIPTION
## Summary

- Add `ProblemDetails` interface and `OkResponse<T>` to `packages/shared/src/types.ts`; update `ApiResponse<T> = OkResponse<T> | ProblemDetails`
- Replace `fail()` in `response.ts` with `sendProblem(res, status, detail, opts?)` — sets `Content-Type: application/problem+json` automatically
- Add `PROBLEM_TYPES` constants (`/problems/validation-error`, `/problems/not-found`, `/problems/conflict`, `/problems/anki-connect-unavailable`, `/problems/internal-error`)
- Update error middleware to map `AnkinikiError` codes to problem types and include `instance` (request path)
- Update all routes (health, export, ml, import) to use `sendProblem()`

## Error response shape

```json
{
  "type": "/problems/validation-error",
  "title": "Validation Error",
  "status": 400,
  "detail": "Deck 'MyDeck' already exists",
  "instance": "/api/decks"
}
```

Extension members (e.g. `errors`, `filename`, `ankiConnect`) are spread in where helpful per RFC 7807 §3.2.

> Note: this PR is stacked on top of #38 (`ok()` helper). Merge #38 first.

## Test plan

- [x] `npm run build` passes for `shared` and `backend`
- [x] All 63 tests pass (60 shared + 3 backend)
- [x] No `fail()` calls remain in any route file

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)