### PR TITLE
#29 Replace hardcoded AnkiConnect/Server URLs with shared constants

### DIFF
--- a/apps/cli/src/commands/config.ts
+++ b/apps/cli/src/commands/config.ts
@@ -3,6 +3,7 @@ import inquirer from 'inquirer';
 import chalk from 'chalk';
 import { loadConfig, saveConfig, getConfigPath } from '../config';
 import { AnkiClient } from '../anki-client';
+import { ANKI_CONNECT, SERVER } from '@ankiniki/shared';
 
 export function createConfigCommand(): Command {
   const command = new Command('config');
@@ -208,8 +209,8 @@ async function resetConfig(): Promise<void> {
 
   if (confirm.reset) {
     saveConfig({
-      ankiConnectUrl: 'http://localhost:8765',
-      serverUrl: 'http://localhost:3001',
+      ankiConnectUrl: ANKI_CONNECT.DEFAULT_URL,
+      serverUrl: SERVER.DEFAULT_URL,
       defaultDeck: 'Default',
       defaultModel: 'Basic',
       debugMode: false,

--- a/apps/vscode-extension/src/services/configuration.ts
+++ b/apps/vscode-extension/src/services/configuration.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import { ANKI_CONNECT } from '@ankiniki/shared';
 
 export interface AnkinikiConfig {
   ankiConnectUrl: string;
@@ -21,7 +22,7 @@ export class ConfigurationManager {
   getAnkiConnectUrl(): string {
     return this.getConfiguration().get(
       'ankiConnectUrl',
-      'http://localhost:8765'
+      ANKI_CONNECT.DEFAULT_URL
     );
   }
 

--- a/packages/backend/src/config/index.ts
+++ b/packages/backend/src/config/index.ts
@@ -1,6 +1,6 @@
 import dotenv from 'dotenv';
 import { z } from 'zod';
-import { SERVER } from '@ankiniki/shared';
+import { ANKI_CONNECT, SERVER } from '@ankiniki/shared';
 
 dotenv.config();
 
@@ -9,8 +9,10 @@ const ConfigSchema = z.object({
   NODE_ENV: z
     .enum(['development', 'production', 'test'])
     .default('development'),
-  ANKI_CONNECT_URL: z.string().default('http://localhost:8765'),
-  ANKI_CONNECT_TIMEOUT: z.string().default('5000'),
+  ANKI_CONNECT_URL: z.string().default(ANKI_CONNECT.DEFAULT_URL),
+  ANKI_CONNECT_TIMEOUT: z
+    .string()
+    .default(String(ANKI_CONNECT.DEFAULT_TIMEOUT)),
   ML_SERVICE_URL: z.string().default('http://localhost:8000'),
   ML_SERVICE_TIMEOUT: z.string().default('30000'),
   LOG_LEVEL: z.string().default('info'),

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { ANKI_CONNECT } from './constants';
 
 // Card types
 export const CardSchema = z.object({
@@ -74,8 +75,8 @@ export type ApiResponse<T = unknown> = OkResponse<T> | ProblemDetails;
 
 // Configuration types
 export const ConfigSchema = z.object({
-  ankiConnectUrl: z.string().default('http://localhost:8765'),
-  ankiConnectTimeout: z.number().default(5000),
+  ankiConnectUrl: z.string().default(ANKI_CONNECT.DEFAULT_URL),
+  ankiConnectTimeout: z.number().default(ANKI_CONNECT.DEFAULT_TIMEOUT),
   autoSync: z.boolean().default(true),
   theme: z.enum(['light', 'dark', 'system']).default('system'),
 });


### PR DESCRIPTION
## Summary
- `ANKI_CONNECT.DEFAULT_URL` / `ANKI_CONNECT.DEFAULT_TIMEOUT` / `SERVER.DEFAULT_URL` from `@ankiniki/shared` now used as the single source of truth
- Removes 4 hardcoded `'http://localhost:8765'` strings spread across `packages/shared`, `packages/backend`, `apps/cli`, and `apps/vscode-extension`
- Also fixes the CLI config-reset handler which had a separate hardcoded `'http://localhost:3001'`

## Files changed
| File | Change |
|------|--------|
| `packages/shared/src/types.ts` | `ConfigSchema` defaults use constants |
| `packages/backend/src/config/index.ts` | Env schema defaults use constants |
| `apps/cli/src/commands/config.ts` | Reset-to-defaults uses constants |
| `apps/vscode-extension/src/services/configuration.ts` | Fallback value uses constants |

## Test plan
- [ ] All four packages compile without errors (`tsc` passes)
- [ ] Backend starts and AnkiConnect URL resolves correctly from env / default
- [ ] CLI `config reset` sets `ankiConnectUrl` to `http://localhost:8765` and `serverUrl` to `http://localhost:3001`

Closes #29 (config constants item)

🤖 Generated with [Claude Code](https://claude.com/claude-code)