### PR TITLE
#29 Add asyncHandler wrapper to all async Express route handlers

### DIFF
--- a/packages/backend/src/routes/cards.ts
+++ b/packages/backend/src/routes/cards.ts
@@ -5,6 +5,7 @@ import { ankiConnect } from '../services/ankiConnect';
 import mlService from '../services/mlService';
 import { logger } from '../utils/logger';
 import { ok } from '../utils/response';
+import { asyncHandler } from '../utils/asyncHandler';
 
 const router = Router();
 
@@ -18,7 +19,7 @@ const AddNoteSchema = z.object({
 
 router.post(
   '/',
-  async (req, res: Response<ApiResponse<{ noteId: number }>>) => {
+  asyncHandler(async (req, res: Response<ApiResponse<{ noteId: number }>>) => {
     try {
       const { deckName, modelName, fields, tags } = AddNoteSchema.parse(
         req.body
@@ -50,7 +51,7 @@ router.post(
       }
       throw error;
     }
-  }
+  })
 );
 
 // Update note fields
@@ -59,57 +60,66 @@ const UpdateNoteSchema = z.object({
   fields: z.record(z.string()),
 });
 
-router.put('/', async (req, res: Response<ApiResponse>) => {
-  try {
-    const { noteId, fields } = UpdateNoteSchema.parse(req.body);
+router.put(
+  '/',
+  asyncHandler(async (req, res: Response<ApiResponse>) => {
+    try {
+      const { noteId, fields } = UpdateNoteSchema.parse(req.body);
 
-    await ankiConnect.updateNoteFields(noteId, fields);
+      await ankiConnect.updateNoteFields(noteId, fields);
 
-    res.json(ok(null, 'Card updated successfully'));
-  } catch (error) {
-    if (error instanceof z.ZodError) {
-      throw new ValidationError(`Invalid update data: ${error.message}`);
+      res.json(ok(null, 'Card updated successfully'));
+    } catch (error) {
+      if (error instanceof z.ZodError) {
+        throw new ValidationError(`Invalid update data: ${error.message}`);
+      }
+      throw error;
     }
-    throw error;
-  }
-});
+  })
+);
 
 // Delete notes
 const DeleteNotesSchema = z.object({
   noteIds: z.array(z.number()),
 });
 
-router.delete('/', async (req, res: Response<ApiResponse>) => {
-  try {
-    const { noteIds } = DeleteNotesSchema.parse(req.body);
+router.delete(
+  '/',
+  asyncHandler(async (req, res: Response<ApiResponse>) => {
+    try {
+      const { noteIds } = DeleteNotesSchema.parse(req.body);
 
-    await ankiConnect.deleteNotes(noteIds);
+      await ankiConnect.deleteNotes(noteIds);
 
-    res.json(ok(null, `${noteIds.length} card(s) deleted successfully`));
-  } catch (error) {
-    if (error instanceof z.ZodError) {
-      throw new ValidationError(`Invalid delete data: ${error.message}`);
+      res.json(ok(null, `${noteIds.length} card(s) deleted successfully`));
+    } catch (error) {
+      if (error instanceof z.ZodError) {
+        throw new ValidationError(`Invalid delete data: ${error.message}`);
+      }
+      throw error;
     }
-    throw error;
-  }
-});
+  })
+);
 
 // Search notes
-router.get('/search', async (req, res: Response<ApiResponse<unknown[]>>) => {
-  try {
-    const query = z.string().parse(req.query.q);
+router.get(
+  '/search',
+  asyncHandler(async (req, res: Response<ApiResponse<unknown[]>>) => {
+    try {
+      const query = z.string().parse(req.query.q);
 
-    const noteIds = await ankiConnect.findNotes(query);
-    const notesInfo = await ankiConnect.notesInfo(noteIds);
+      const noteIds = await ankiConnect.findNotes(query);
+      const notesInfo = await ankiConnect.notesInfo(noteIds);
 
-    res.json(ok(notesInfo));
-  } catch (error) {
-    if (error instanceof z.ZodError) {
-      throw new ValidationError('Invalid search query');
+      res.json(ok(notesInfo));
+    } catch (error) {
+      if (error instanceof z.ZodError) {
+        throw new ValidationError('Invalid search query');
+      }
+      throw error;
     }
-    throw error;
-  }
-});
+  })
+);
 
 // AI-powered card generation with automatic Anki creation
 const GenerateAndCreateSchema = z.object({
@@ -130,165 +140,169 @@ const GenerateAndCreateSchema = z.object({
 
 router.post(
   '/generate-and-create',
-  async (
-    req,
-    res: Response<
-      ApiResponse<{
-        generated_cards: number;
-        created_notes: Array<{
+  asyncHandler(
+    async (
+      req,
+      res: Response<
+        ApiResponse<{
+          generated_cards: number;
+          created_notes: Array<{
+            noteId: number;
+            front: string;
+            success: boolean;
+            error?: string;
+          }>;
+          ml_available: boolean;
+        }>
+      >
+    ) => {
+      try {
+        const validatedData = GenerateAndCreateSchema.parse(req.body);
+
+        logger.info('AI-powered card generation and creation requested', {
+          content_type: validatedData.content_type,
+          deck: validatedData.deckName,
+          max_cards: validatedData.max_cards,
+          programming_language: validatedData.programming_language,
+        });
+
+        // Validate deck exists
+        const existingDecks = await ankiConnect.getDeckNames();
+        if (!existingDecks.includes(validatedData.deckName)) {
+          throw new ValidationError(
+            `Deck '${validatedData.deckName}' does not exist`
+          );
+        }
+
+        // Validate model exists
+        const existingModels = await ankiConnect.modelNames();
+        if (!existingModels.includes(validatedData.modelName)) {
+          throw new ValidationError(
+            `Model '${validatedData.modelName}' does not exist`
+          );
+        }
+
+        // Generate cards using ML service
+        const mlResult = await mlService.generateCards({
+          content: validatedData.content,
+          content_type: validatedData.content_type,
+          difficulty_level: validatedData.difficulty_level,
+          max_cards: validatedData.max_cards,
+          focus_areas: validatedData.focus_areas,
+          programming_language: validatedData.programming_language,
+          tags: validatedData.additional_tags,
+        });
+
+        if (!mlResult.success) {
+          throw new ValidationError(
+            `Failed to generate cards: ${mlResult.error}`
+          );
+        }
+
+        const createdNotes: Array<{
           noteId: number;
           front: string;
           success: boolean;
           error?: string;
-        }>;
-        ml_available: boolean;
-      }>
-    >
-  ): Promise<void> => {
-    try {
-      const validatedData = GenerateAndCreateSchema.parse(req.body);
+        }> = [];
 
-      logger.info('AI-powered card generation and creation requested', {
-        content_type: validatedData.content_type,
-        deck: validatedData.deckName,
-        max_cards: validatedData.max_cards,
-        programming_language: validatedData.programming_language,
-      });
+        // Create cards in Anki
+        for (const card of mlResult.cards) {
+          try {
+            // Enhance question if requested
+            let front = card.front;
+            if (validatedData.auto_enhance_questions && card.front) {
+              const enhanceResult = await mlService.enhanceQuestion({
+                original_question: card.front,
+                context: card.back,
+                target_difficulty: validatedData.difficulty_level,
+                question_type: 'concept',
+                programming_language: validatedData.programming_language,
+              });
 
-      // Validate deck exists
-      const existingDecks = await ankiConnect.getDeckNames();
-      if (!existingDecks.includes(validatedData.deckName)) {
-        throw new ValidationError(
-          `Deck '${validatedData.deckName}' does not exist`
-        );
-      }
+              if (enhanceResult.success) {
+                front = enhanceResult.enhanced_question.enhanced_question;
+              }
+            }
 
-      // Validate model exists
-      const existingModels = await ankiConnect.modelNames();
-      if (!existingModels.includes(validatedData.modelName)) {
-        throw new ValidationError(
-          `Model '${validatedData.modelName}' does not exist`
-        );
-      }
+            // Prepare fields based on model
+            const fields: Record<string, string> = {};
+            if (validatedData.modelName === 'Basic') {
+              fields['Front'] = front;
+              fields['Back'] = card.back;
+            } else if (validatedData.modelName === 'Cloze') {
+              // For cloze, put everything in Text field
+              fields['Text'] = `${front}\n\n${card.back}`;
+            } else {
+              // Default fallback
+              fields['Front'] = front;
+              fields['Back'] = card.back;
+            }
 
-      // Generate cards using ML service
-      const mlResult = await mlService.generateCards({
-        content: validatedData.content,
-        content_type: validatedData.content_type,
-        difficulty_level: validatedData.difficulty_level,
-        max_cards: validatedData.max_cards,
-        focus_areas: validatedData.focus_areas,
-        programming_language: validatedData.programming_language,
-        tags: validatedData.additional_tags,
-      });
+            // Combine ML-generated tags with user tags
+            const allTags = [
+              ...card.tags,
+              ...validatedData.additional_tags,
+              'ai-generated',
+              `difficulty-${card.difficulty}`,
+              `confidence-${Math.round(card.confidence_score * 100)}`,
+            ];
 
-      if (!mlResult.success) {
-        throw new ValidationError(
-          `Failed to generate cards: ${mlResult.error}`
-        );
-      }
+            // Add programming language tag if available
+            if (validatedData.programming_language) {
+              allTags.push(validatedData.programming_language);
+            }
 
-      const createdNotes: Array<{
-        noteId: number;
-        front: string;
-        success: boolean;
-        error?: string;
-      }> = [];
+            const noteId = await ankiConnect.addNote(
+              validatedData.deckName,
+              validatedData.modelName,
+              fields,
+              allTags
+            );
 
-      // Create cards in Anki
-      for (const card of mlResult.cards) {
-        try {
-          // Enhance question if requested
-          let front = card.front;
-          if (validatedData.auto_enhance_questions && card.front) {
-            const enhanceResult = await mlService.enhanceQuestion({
-              original_question: card.front,
-              context: card.back,
-              target_difficulty: validatedData.difficulty_level,
-              question_type: 'concept',
-              programming_language: validatedData.programming_language,
+            createdNotes.push({
+              noteId,
+              front,
+              success: true,
             });
 
-            if (enhanceResult.success) {
-              front = enhanceResult.enhanced_question.enhanced_question;
-            }
+            logger.info('Successfully created AI-generated card', {
+              noteId,
+              confidence: card.confidence_score,
+            });
+          } catch (error) {
+            logger.error('Failed to create AI-generated card', error);
+            createdNotes.push({
+              noteId: -1,
+              front: card.front,
+              success: false,
+              error: error instanceof Error ? error.message : 'Unknown error',
+            });
           }
-
-          // Prepare fields based on model
-          const fields: Record<string, string> = {};
-          if (validatedData.modelName === 'Basic') {
-            fields['Front'] = front;
-            fields['Back'] = card.back;
-          } else if (validatedData.modelName === 'Cloze') {
-            // For cloze, put everything in Text field
-            fields['Text'] = `${front}\n\n${card.back}`;
-          } else {
-            // Default fallback
-            fields['Front'] = front;
-            fields['Back'] = card.back;
-          }
-
-          // Combine ML-generated tags with user tags
-          const allTags = [
-            ...card.tags,
-            ...validatedData.additional_tags,
-            'ai-generated',
-            `difficulty-${card.difficulty}`,
-            `confidence-${Math.round(card.confidence_score * 100)}`,
-          ];
-
-          // Add programming language tag if available
-          if (validatedData.programming_language) {
-            allTags.push(validatedData.programming_language);
-          }
-
-          const noteId = await ankiConnect.addNote(
-            validatedData.deckName,
-            validatedData.modelName,
-            fields,
-            allTags
-          );
-
-          createdNotes.push({
-            noteId,
-            front,
-            success: true,
-          });
-
-          logger.info('Successfully created AI-generated card', {
-            noteId,
-            confidence: card.confidence_score,
-          });
-        } catch (error) {
-          logger.error('Failed to create AI-generated card', error);
-          createdNotes.push({
-            noteId: -1,
-            front: card.front,
-            success: false,
-            error: error instanceof Error ? error.message : 'Unknown error',
-          });
         }
-      }
 
-      const successfulCards = createdNotes.filter(note => note.success).length;
+        const successfulCards = createdNotes.filter(
+          note => note.success
+        ).length;
 
-      res.status(201).json(
-        ok(
-          {
-            generated_cards: mlResult.cards.length,
-            created_notes: createdNotes,
-            ml_available: mlService.getAvailability(),
-          },
-          `Successfully generated ${mlResult.cards.length} cards and created ${successfulCards} in Anki`
-        )
-      );
-    } catch (error) {
-      if (error instanceof z.ZodError) {
-        throw new ValidationError(`Invalid request data: ${error.message}`);
+        res.status(201).json(
+          ok(
+            {
+              generated_cards: mlResult.cards.length,
+              created_notes: createdNotes,
+              ml_available: mlService.getAvailability(),
+            },
+            `Successfully generated ${mlResult.cards.length} cards and created ${successfulCards} in Anki`
+          )
+        );
+      } catch (error) {
+        if (error instanceof z.ZodError) {
+          throw new ValidationError(`Invalid request data: ${error.message}`);
+        }
+        throw error;
       }
-      throw error;
     }
-  }
+  )
 );
 
 export default router;

--- a/packages/backend/src/routes/decks.ts
+++ b/packages/backend/src/routes/decks.ts
@@ -4,47 +4,54 @@ import { ApiResponse, ValidationError } from '@ankiniki/shared';
 import { ankiConnect } from '../services/ankiConnect';
 import { logger } from '../utils/logger';
 import { ok } from '../utils/response';
+import { asyncHandler } from '../utils/asyncHandler';
 
 const router = Router();
 
 // Get all decks
-router.get('/', async (req, res: Response<ApiResponse<string[]>>) => {
-  try {
-    const deckNames = await ankiConnect.getDeckNames();
-    res.json(ok(deckNames));
-  } catch (error) {
-    logger.error('Failed to get decks', error);
-    throw error;
-  }
-});
+router.get(
+  '/',
+  asyncHandler(async (req, res: Response<ApiResponse<string[]>>) => {
+    try {
+      const deckNames = await ankiConnect.getDeckNames();
+      res.json(ok(deckNames));
+    } catch (error) {
+      logger.error('Failed to get decks', error);
+      throw error;
+    }
+  })
+);
 
 // Create deck
 const CreateDeckSchema = z.object({
   name: z.string().min(1).max(100),
 });
 
-router.post('/', async (req, res: Response<ApiResponse<{ id: number }>>) => {
-  try {
-    const { name } = CreateDeckSchema.parse(req.body);
+router.post(
+  '/',
+  asyncHandler(async (req, res: Response<ApiResponse<{ id: number }>>) => {
+    try {
+      const { name } = CreateDeckSchema.parse(req.body);
 
-    // Check if deck already exists
-    const existingDecks = await ankiConnect.getDeckNames();
-    if (existingDecks.includes(name)) {
-      throw new ValidationError(`Deck '${name}' already exists`);
+      // Check if deck already exists
+      const existingDecks = await ankiConnect.getDeckNames();
+      if (existingDecks.includes(name)) {
+        throw new ValidationError(`Deck '${name}' already exists`);
+      }
+
+      const deckId = await ankiConnect.createDeck(name);
+
+      res
+        .status(201)
+        .json(ok({ id: deckId }, `Deck '${name}' created successfully`));
+    } catch (error) {
+      if (error instanceof z.ZodError) {
+        throw new ValidationError(`Invalid deck data: ${error.message}`);
+      }
+      throw error;
     }
-
-    const deckId = await ankiConnect.createDeck(name);
-
-    res
-      .status(201)
-      .json(ok({ id: deckId }, `Deck '${name}' created successfully`));
-  } catch (error) {
-    if (error instanceof z.ZodError) {
-      throw new ValidationError(`Invalid deck data: ${error.message}`);
-    }
-    throw error;
-  }
-});
+  })
+);
 
 // Delete deck
 const DeleteDeckSchema = z.object({
@@ -52,26 +59,29 @@ const DeleteDeckSchema = z.object({
   deleteCards: z.boolean().default(false),
 });
 
-router.delete('/:name', async (req, res: Response<ApiResponse>) => {
-  try {
-    const { name } = req.params;
-    const { deleteCards } = DeleteDeckSchema.parse(req.body);
+router.delete(
+  '/:name',
+  asyncHandler(async (req, res: Response<ApiResponse>) => {
+    try {
+      const { name } = req.params;
+      const { deleteCards } = DeleteDeckSchema.parse(req.body);
 
-    // Check if deck exists
-    const existingDecks = await ankiConnect.getDeckNames();
-    if (!existingDecks.includes(name)) {
-      throw new ValidationError(`Deck '${name}' does not exist`);
+      // Check if deck exists
+      const existingDecks = await ankiConnect.getDeckNames();
+      if (!existingDecks.includes(name)) {
+        throw new ValidationError(`Deck '${name}' does not exist`);
+      }
+
+      await ankiConnect.deleteDeck(name, deleteCards);
+
+      res.json(ok(null, `Deck '${name}' deleted successfully`));
+    } catch (error) {
+      if (error instanceof z.ZodError) {
+        throw new ValidationError(`Invalid delete request: ${error.message}`);
+      }
+      throw error;
     }
-
-    await ankiConnect.deleteDeck(name, deleteCards);
-
-    res.json(ok(null, `Deck '${name}' deleted successfully`));
-  } catch (error) {
-    if (error instanceof z.ZodError) {
-      throw new ValidationError(`Invalid delete request: ${error.message}`);
-    }
-    throw error;
-  }
-});
+  })
+);
 
 export default router;

--- a/packages/backend/src/routes/export.ts
+++ b/packages/backend/src/routes/export.ts
@@ -9,6 +9,7 @@ import path from 'path';
 import { ankiConnect } from '../services/ankiConnect';
 import { logger } from '../utils/logger';
 import { sendProblem, PROBLEM_TYPES } from '../utils/response';
+import { asyncHandler } from '../utils/asyncHandler';
 
 const router = Router();
 
@@ -23,90 +24,96 @@ const router = Router();
  *   GET /api/export/deck/JavaScript
  *   GET /api/export/deck/Programming%3A%3ARust?includeSched=true
  */
-router.get('/deck/:name', async (req: Request, res: Response) => {
-  const deckName = decodeURIComponent(req.params.name);
-  const includeSched = req.query.includeSched === 'true';
+router.get(
+  '/deck/:name',
+  asyncHandler(async (req: Request, res: Response) => {
+    const deckName = decodeURIComponent(req.params.name);
+    const includeSched = req.query.includeSched === 'true';
 
-  const tmpFile = path.join(os.tmpdir(), `ankiniki-export-${Date.now()}.apkg`);
-
-  try {
-    // Verify deck exists
-    const decks = await ankiConnect.getDeckNames();
-    if (!decks.includes(deckName)) {
-      return sendProblem(res, 404, `Deck "${deckName}" not found`, {
-        type: PROBLEM_TYPES.NOT_FOUND,
-        instance: req.path,
-      });
-    }
-
-    logger.info('Exporting deck', { deckName, includeSched, tmpFile });
-
-    const exported = await ankiConnect.exportPackage(
-      deckName,
-      tmpFile,
-      includeSched
+    const tmpFile = path.join(
+      os.tmpdir(),
+      `ankiniki-export-${Date.now()}.apkg`
     );
-    if (!exported) {
-      return sendProblem(res, 500, 'AnkiConnect failed to export the deck', {
-        type: PROBLEM_TYPES.ANKI_CONNECT,
-        instance: req.path,
-      });
-    }
 
-    if (!fs.existsSync(tmpFile)) {
-      return sendProblem(res, 500, 'Export file was not created', {
-        type: PROBLEM_TYPES.INTERNAL,
-        instance: req.path,
-      });
-    }
+    try {
+      // Verify deck exists
+      const decks = await ankiConnect.getDeckNames();
+      if (!decks.includes(deckName)) {
+        return sendProblem(res, 404, `Deck "${deckName}" not found`, {
+          type: PROBLEM_TYPES.NOT_FOUND,
+          instance: req.path,
+        });
+      }
 
-    const stat = fs.statSync(tmpFile);
-    const safeFileName = `${deckName.replace(/[^a-zA-Z0-9_\-. ]/g, '_')}.apkg`;
+      logger.info('Exporting deck', { deckName, includeSched, tmpFile });
 
-    logger.info('Streaming export file', {
-      deckName,
-      size: stat.size,
-      safeFileName,
-    });
+      const exported = await ankiConnect.exportPackage(
+        deckName,
+        tmpFile,
+        includeSched
+      );
+      if (!exported) {
+        return sendProblem(res, 500, 'AnkiConnect failed to export the deck', {
+          type: PROBLEM_TYPES.ANKI_CONNECT,
+          instance: req.path,
+        });
+      }
 
-    res.setHeader('Content-Type', 'application/octet-stream');
-    res.setHeader(
-      'Content-Disposition',
-      `attachment; filename="${safeFileName}"`
-    );
-    res.setHeader('Content-Length', stat.size);
-
-    const stream = fs.createReadStream(tmpFile);
-    stream.pipe(res);
-
-    stream.on('end', () => {
-      fs.unlink(tmpFile, err => {
-        if (err) {
-          logger.warn('Failed to delete temp export file', { tmpFile });
-        }
-      });
-    });
-
-    stream.on('error', err => {
-      logger.error('Error streaming export file', err);
-      fs.unlink(tmpFile, () => {});
-      if (!res.headersSent) {
-        sendProblem(res, 500, 'Failed to stream file', {
+      if (!fs.existsSync(tmpFile)) {
+        return sendProblem(res, 500, 'Export file was not created', {
           type: PROBLEM_TYPES.INTERNAL,
           instance: req.path,
         });
       }
-    });
-  } catch (error) {
-    fs.unlink(tmpFile, () => {});
-    logger.error('Deck export error', error);
-    sendProblem(
-      res,
-      500,
-      error instanceof Error ? error.message : 'Internal server error',
-      { type: PROBLEM_TYPES.INTERNAL, instance: req.path }
-    );
-  }
-});
+
+      const stat = fs.statSync(tmpFile);
+      const safeFileName = `${deckName.replace(/[^a-zA-Z0-9_\-. ]/g, '_')}.apkg`;
+
+      logger.info('Streaming export file', {
+        deckName,
+        size: stat.size,
+        safeFileName,
+      });
+
+      res.setHeader('Content-Type', 'application/octet-stream');
+      res.setHeader(
+        'Content-Disposition',
+        `attachment; filename="${safeFileName}"`
+      );
+      res.setHeader('Content-Length', stat.size);
+
+      const stream = fs.createReadStream(tmpFile);
+      stream.pipe(res);
+
+      stream.on('end', () => {
+        fs.unlink(tmpFile, err => {
+          if (err) {
+            logger.warn('Failed to delete temp export file', { tmpFile });
+          }
+        });
+      });
+
+      stream.on('error', err => {
+        logger.error('Error streaming export file', err);
+        fs.unlink(tmpFile, () => {});
+        if (!res.headersSent) {
+          sendProblem(res, 500, 'Failed to stream file', {
+            type: PROBLEM_TYPES.INTERNAL,
+            instance: req.path,
+          });
+        }
+      });
+    } catch (error) {
+      fs.unlink(tmpFile, () => {});
+      logger.error('Deck export error', error);
+      sendProblem(
+        res,
+        500,
+        error instanceof Error ? error.message : 'Internal server error',
+        { type: PROBLEM_TYPES.INTERNAL, instance: req.path }
+      );
+    }
+  })
+);
 
 export default router;

--- a/packages/backend/src/routes/health.ts
+++ b/packages/backend/src/routes/health.ts
@@ -2,6 +2,7 @@ import { Router } from 'express';
 import { ankiConnect } from '../services/ankiConnect';
 import { config } from '../config';
 import { ok, sendProblem, PROBLEM_TYPES } from '../utils/response';
+import { asyncHandler } from '../utils/asyncHandler';
 
 const router = Router();
 
@@ -15,28 +16,31 @@ interface HealthStatus {
   };
 }
 
-router.get('/', async (req, res) => {
-  const ankiConnected = await ankiConnect.ping();
+router.get(
+  '/',
+  asyncHandler(async (req, res) => {
+    const ankiConnected = await ankiConnect.ping();
 
-  const healthData: HealthStatus = {
-    status: ankiConnected ? 'healthy' : 'unhealthy',
-    version: '0.1.0',
-    timestamp: new Date().toISOString(),
-    ankiConnect: {
-      connected: ankiConnected,
-      url: config.ankiConnect.url,
-    },
-  };
+    const healthData: HealthStatus = {
+      status: ankiConnected ? 'healthy' : 'unhealthy',
+      version: '0.1.0',
+      timestamp: new Date().toISOString(),
+      ankiConnect: {
+        connected: ankiConnected,
+        url: config.ankiConnect.url,
+      },
+    };
 
-  if (ankiConnected) {
-    res.status(200).json(ok(healthData, 'All services are healthy'));
-  } else {
-    sendProblem(res, 503, 'AnkiConnect is not available', {
-      type: PROBLEM_TYPES.ANKI_CONNECT,
-      instance: req.path,
-      ankiConnect: healthData.ankiConnect,
-    });
-  }
-});
+    if (ankiConnected) {
+      res.status(200).json(ok(healthData, 'All services are healthy'));
+    } else {
+      sendProblem(res, 503, 'AnkiConnect is not available', {
+        type: PROBLEM_TYPES.ANKI_CONNECT,
+        instance: req.path,
+        ankiConnect: healthData.ankiConnect,
+      });
+    }
+  })
+);
 
 export default router;

--- a/packages/backend/src/routes/import/csv.ts
+++ b/packages/backend/src/routes/import/csv.ts
@@ -11,6 +11,7 @@ import {
 import { logger } from '../../utils/logger';
 import { ok, sendProblem, PROBLEM_TYPES } from '../../utils/response';
 import { upload, createCards } from './shared';
+import { asyncHandler } from '../../utils/asyncHandler';
 
 const router = Router();
 
@@ -42,7 +43,7 @@ function parseCsvContent(
 router.post(
   '/',
   upload.single('file'),
-  async (req: MulterRequest, res: Response) => {
+  asyncHandler(async (req: MulterRequest, res: Response) => {
     try {
       if (!req.file) {
         return sendProblem(res, 400, 'No CSV file uploaded', {
@@ -138,7 +139,7 @@ router.post(
         }
       );
     }
-  }
+  })
 );
 
 /**
@@ -151,7 +152,7 @@ router.post(
 router.post(
   '/preview',
   upload.single('file'),
-  async (req: MulterRequest, res: Response) => {
+  asyncHandler(async (req: MulterRequest, res: Response) => {
     try {
       if (!req.file) {
         return sendProblem(res, 400, 'No CSV file uploaded', {
@@ -204,7 +205,7 @@ router.post(
         }
       );
     }
-  }
+  })
 );
 
 export default router;

--- a/packages/backend/src/routes/import/json.ts
+++ b/packages/backend/src/routes/import/json.ts
@@ -10,6 +10,7 @@ import {
 import { logger } from '../../utils/logger';
 import { ok, sendProblem, PROBLEM_TYPES } from '../../utils/response';
 import { upload, createCards } from './shared';
+import { asyncHandler } from '../../utils/asyncHandler';
 
 const router = Router();
 
@@ -27,7 +28,7 @@ interface MulterRequest extends Request {
 router.post(
   '/',
   upload.single('file'),
-  async (req: MulterRequest, res: Response) => {
+  asyncHandler(async (req: MulterRequest, res: Response) => {
     try {
       if (!req.file) {
         return sendProblem(res, 400, 'No JSON file uploaded', {
@@ -127,7 +128,7 @@ router.post(
         }
       );
     }
-  }
+  })
 );
 
 /**
@@ -140,7 +141,7 @@ router.post(
 router.post(
   '/preview',
   upload.single('file'),
-  async (req: MulterRequest, res: Response) => {
+  asyncHandler(async (req: MulterRequest, res: Response) => {
     try {
       if (!req.file) {
         return sendProblem(res, 400, 'No JSON file uploaded', {
@@ -214,86 +215,89 @@ router.post(
         }
       );
     }
-  }
+  })
 );
 
 /**
  * POST /api/import/json/body
  * Programmatic JSON import — accepts cards directly in the request body.
  */
-router.post('/body', async (req: Request, res: Response) => {
-  try {
-    const { cards, options: rawOptions } = req.body as {
-      cards?: unknown;
-      options?: unknown;
-    };
+router.post(
+  '/body',
+  asyncHandler(async (req: Request, res: Response) => {
+    try {
+      const { cards, options: rawOptions } = req.body as {
+        cards?: unknown;
+        options?: unknown;
+      };
 
-    if (!cards) {
-      return sendProblem(res, 400, 'Missing "cards" field in request body', {
-        type: PROBLEM_TYPES.VALIDATION,
-      });
-    }
+      if (!cards) {
+        return sendProblem(res, 400, 'Missing "cards" field in request body', {
+          type: PROBLEM_TYPES.VALIDATION,
+        });
+      }
 
-    const validatedOptions = JsonImportOptionsSchema.parse(rawOptions ?? {});
-    const jsonData: JsonImportFormat | JsonCard[] = Array.isArray(cards)
-      ? (cards as JsonCard[])
-      : { cards: cards as JsonCard[] };
+      const validatedOptions = JsonImportOptionsSchema.parse(rawOptions ?? {});
+      const jsonData: JsonImportFormat | JsonCard[] = Array.isArray(cards)
+        ? (cards as JsonCard[])
+        : { cards: cards as JsonCard[] };
 
-    const processedCards = processJsonCards(jsonData, validatedOptions);
-    const { valid: validCards, errors: invalidCards } =
-      validateCards(processedCards);
+      const processedCards = processJsonCards(jsonData, validatedOptions);
+      const { valid: validCards, errors: invalidCards } =
+        validateCards(processedCards);
 
-    logger.info('JSON body import started', { cards: processedCards.length });
+      logger.info('JSON body import started', { cards: processedCards.length });
 
-    if (validatedOptions.dryRun) {
-      return res.json(
+      if (validatedOptions.dryRun) {
+        return res.json(
+          ok({
+            dryRun: true,
+            totalCards: processedCards.length,
+            validCards: validCards.length,
+            invalidCards: invalidCards.length,
+            preview: validCards.slice(0, 5),
+            errors: invalidCards,
+          })
+        );
+      }
+
+      const { results, successfulCards, failedCards } = await createCards(
+        validCards,
+        invalidCards,
+        'json-body'
+      );
+
+      res.json(
         ok({
-          dryRun: true,
           totalCards: processedCards.length,
-          validCards: validCards.length,
-          invalidCards: invalidCards.length,
-          preview: validCards.slice(0, 5),
-          errors: invalidCards,
+          successfulCards,
+          failedCards: failedCards + invalidCards.length,
+          results: [...results, ...invalidCards],
+          summary: {
+            imported: successfulCards,
+            failed: failedCards,
+            invalid: invalidCards.length,
+          },
         })
       );
-    }
-
-    const { results, successfulCards, failedCards } = await createCards(
-      validCards,
-      invalidCards,
-      'json-body'
-    );
-
-    res.json(
-      ok({
-        totalCards: processedCards.length,
-        successfulCards,
-        failedCards: failedCards + invalidCards.length,
-        results: [...results, ...invalidCards],
-        summary: {
-          imported: successfulCards,
-          failed: failedCards,
-          invalid: invalidCards.length,
-        },
-      })
-    );
-  } catch (error) {
-    if (error instanceof z.ZodError) {
-      return sendProblem(res, 400, 'Invalid import options', {
-        type: PROBLEM_TYPES.VALIDATION,
-        errors: error.errors,
-      });
-    }
-    logger.error('JSON body import error:', error);
-    sendProblem(
-      res,
-      500,
-      error instanceof Error ? error.message : 'Internal server error',
-      {
-        type: PROBLEM_TYPES.INTERNAL,
+    } catch (error) {
+      if (error instanceof z.ZodError) {
+        return sendProblem(res, 400, 'Invalid import options', {
+          type: PROBLEM_TYPES.VALIDATION,
+          errors: error.errors,
+        });
       }
-    );
-  }
-});
+      logger.error('JSON body import error:', error);
+      sendProblem(
+        res,
+        500,
+        error instanceof Error ? error.message : 'Internal server error',
+        {
+          type: PROBLEM_TYPES.INTERNAL,
+        }
+      );
+    }
+  })
+);
 
 export default router;

--- a/packages/backend/src/routes/import/markdown.ts
+++ b/packages/backend/src/routes/import/markdown.ts
@@ -8,6 +8,7 @@ import {
 import { logger } from '../../utils/logger';
 import { ok, sendProblem, PROBLEM_TYPES } from '../../utils/response';
 import { upload, createCards } from './shared';
+import { asyncHandler } from '../../utils/asyncHandler';
 
 const router = Router();
 
@@ -25,7 +26,7 @@ interface MulterRequest extends Request {
 router.post(
   '/',
   upload.single('file'),
-  async (req: MulterRequest, res: Response) => {
+  asyncHandler(async (req: MulterRequest, res: Response) => {
     try {
       if (!req.file) {
         return sendProblem(res, 400, 'No Markdown file uploaded', {
@@ -112,7 +113,7 @@ router.post(
         }
       );
     }
-  }
+  })
 );
 
 /**
@@ -125,7 +126,7 @@ router.post(
 router.post(
   '/preview',
   upload.single('file'),
-  async (req: MulterRequest, res: Response) => {
+  asyncHandler(async (req: MulterRequest, res: Response) => {
     try {
       if (!req.file) {
         return sendProblem(res, 400, 'No Markdown file uploaded', {
@@ -175,7 +176,7 @@ router.post(
         }
       );
     }
-  }
+  })
 );
 
 export default router;

--- a/packages/backend/src/routes/ml.ts
+++ b/packages/backend/src/routes/ml.ts
@@ -8,6 +8,7 @@ import { z } from 'zod';
 import { logger } from '../utils/logger';
 import mlService from '../services/mlService';
 import { ok, sendProblem, PROBLEM_TYPES } from '../utils/response';
+import { asyncHandler } from '../utils/asyncHandler';
 
 const router = Router();
 
@@ -100,21 +101,24 @@ const enhanceQuestionSchema = z.object({
  *       200:
  *         description: ML service status
  */
-router.get('/health', async (req: Request, res: Response) => {
-  try {
-    const isAvailable = await mlService.checkHealth();
-    const models = await mlService.getAvailableModels();
+router.get(
+  '/health',
+  asyncHandler(async (req: Request, res: Response) => {
+    try {
+      const isAvailable = await mlService.checkHealth();
+      const models = await mlService.getAvailableModels();
 
-    res.json(
-      ok({ available: isAvailable, base_url: mlService.getBaseURL(), models })
-    );
-  } catch (error) {
-    logger.error('Error checking ML service health:', error);
-    sendProblem(res, 500, 'Failed to check ML service health', {
-      type: PROBLEM_TYPES.INTERNAL,
-    });
-  }
-});
+      res.json(
+        ok({ available: isAvailable, base_url: mlService.getBaseURL(), models })
+      );
+    } catch (error) {
+      logger.error('Error checking ML service health:', error);
+      sendProblem(res, 500, 'Failed to check ML service health', {
+        type: PROBLEM_TYPES.INTERNAL,
+      });
+    }
+  })
+);
 
 /**
  * @swagger
@@ -146,39 +150,42 @@ router.get('/health', async (req: Request, res: Response) => {
  *       200:
  *         description: Generated flashcards
  */
-router.post('/generate/cards', async (req: Request, res: Response) => {
-  try {
-    const validatedData = generateCardsSchema.parse(req.body);
+router.post(
+  '/generate/cards',
+  asyncHandler(async (req: Request, res: Response) => {
+    try {
+      const validatedData = generateCardsSchema.parse(req.body);
 
-    logger.info('Generating cards via ML service', {
-      content_type: validatedData.content_type,
-      max_cards: validatedData.max_cards,
-      programming_language: validatedData.programming_language,
-    });
+      logger.info('Generating cards via ML service', {
+        content_type: validatedData.content_type,
+        max_cards: validatedData.max_cards,
+        programming_language: validatedData.programming_language,
+      });
 
-    const result = await mlService.generateCards(validatedData);
+      const result = await mlService.generateCards(validatedData);
 
-    if (result.success) {
-      res.json(ok(result));
-    } else {
-      sendProblem(res, 500, result.error || 'Failed to generate cards', {
+      if (result.success) {
+        res.json(ok(result));
+      } else {
+        sendProblem(res, 500, result.error || 'Failed to generate cards', {
+          type: PROBLEM_TYPES.INTERNAL,
+        });
+      }
+    } catch (error) {
+      if (error instanceof z.ZodError) {
+        return sendProblem(res, 400, 'Invalid request data', {
+          type: PROBLEM_TYPES.VALIDATION,
+          errors: error.errors,
+        });
+      }
+
+      logger.error('Error generating cards:', error);
+      sendProblem(res, 500, 'Internal server error', {
         type: PROBLEM_TYPES.INTERNAL,
       });
     }
-  } catch (error) {
-    if (error instanceof z.ZodError) {
-      return sendProblem(res, 400, 'Invalid request data', {
-        type: PROBLEM_TYPES.VALIDATION,
-        errors: error.errors,
-      });
-    }
-
-    logger.error('Error generating cards:', error);
-    sendProblem(res, 500, 'Internal server error', {
-      type: PROBLEM_TYPES.INTERNAL,
-    });
-  }
-});
+  })
+);
 
 /**
  * @swagger
@@ -203,39 +210,42 @@ router.post('/generate/cards', async (req: Request, res: Response) => {
  *       200:
  *         description: Processed content with extracted materials
  */
-router.post('/process/content', async (req: Request, res: Response) => {
-  try {
-    const validatedData = processContentSchema.parse(req.body);
+router.post(
+  '/process/content',
+  asyncHandler(async (req: Request, res: Response) => {
+    try {
+      const validatedData = processContentSchema.parse(req.body);
 
-    logger.info('Processing content via ML service', {
-      content_type: validatedData.content_type,
-      extract_code: validatedData.extract_code,
-      extract_concepts: validatedData.extract_concepts,
-    });
+      logger.info('Processing content via ML service', {
+        content_type: validatedData.content_type,
+        extract_code: validatedData.extract_code,
+        extract_concepts: validatedData.extract_concepts,
+      });
 
-    const result = await mlService.processContent(validatedData);
+      const result = await mlService.processContent(validatedData);
 
-    if (result.success) {
-      res.json(ok(result));
-    } else {
-      sendProblem(res, 500, result.error || 'Failed to process content', {
+      if (result.success) {
+        res.json(ok(result));
+      } else {
+        sendProblem(res, 500, result.error || 'Failed to process content', {
+          type: PROBLEM_TYPES.INTERNAL,
+        });
+      }
+    } catch (error) {
+      if (error instanceof z.ZodError) {
+        return sendProblem(res, 400, 'Invalid request data', {
+          type: PROBLEM_TYPES.VALIDATION,
+          errors: error.errors,
+        });
+      }
+
+      logger.error('Error processing content:', error);
+      sendProblem(res, 500, 'Internal server error', {
         type: PROBLEM_TYPES.INTERNAL,
       });
     }
-  } catch (error) {
-    if (error instanceof z.ZodError) {
-      return sendProblem(res, 400, 'Invalid request data', {
-        type: PROBLEM_TYPES.VALIDATION,
-        errors: error.errors,
-      });
-    }
-
-    logger.error('Error processing content:', error);
-    sendProblem(res, 500, 'Internal server error', {
-      type: PROBLEM_TYPES.INTERNAL,
-    });
-  }
-});
+  })
+);
 
 /**
  * @swagger
@@ -260,7 +270,7 @@ router.post('/process/content', async (req: Request, res: Response) => {
 router.post(
   '/process/file',
   upload.single('file'),
-  async (req: Request, res: Response) => {
+  asyncHandler(async (req: Request, res: Response) => {
     try {
       if (!req.file) {
         return sendProblem(res, 400, 'No file uploaded', {
@@ -299,7 +309,7 @@ router.post(
         { type: PROBLEM_TYPES.INTERNAL }
       );
     }
-  }
+  })
 );
 
 /**
@@ -327,39 +337,42 @@ router.post(
  *       200:
  *         description: Enhanced question
  */
-router.post('/enhance/question', async (req: Request, res: Response) => {
-  try {
-    const validatedData = enhanceQuestionSchema.parse(req.body);
+router.post(
+  '/enhance/question',
+  asyncHandler(async (req: Request, res: Response) => {
+    try {
+      const validatedData = enhanceQuestionSchema.parse(req.body);
 
-    logger.info('Enhancing question via ML service', {
-      target_difficulty: validatedData.target_difficulty,
-      question_type: validatedData.question_type,
-      has_context: !!validatedData.context,
-    });
+      logger.info('Enhancing question via ML service', {
+        target_difficulty: validatedData.target_difficulty,
+        question_type: validatedData.question_type,
+        has_context: !!validatedData.context,
+      });
 
-    const result = await mlService.enhanceQuestion(validatedData);
+      const result = await mlService.enhanceQuestion(validatedData);
 
-    if (result.success) {
-      res.json(ok(result));
-    } else {
-      sendProblem(res, 500, result.error || 'Failed to enhance question', {
+      if (result.success) {
+        res.json(ok(result));
+      } else {
+        sendProblem(res, 500, result.error || 'Failed to enhance question', {
+          type: PROBLEM_TYPES.INTERNAL,
+        });
+      }
+    } catch (error) {
+      if (error instanceof z.ZodError) {
+        return sendProblem(res, 400, 'Invalid request data', {
+          type: PROBLEM_TYPES.VALIDATION,
+          errors: error.errors,
+        });
+      }
+
+      logger.error('Error enhancing question:', error);
+      sendProblem(res, 500, 'Internal server error', {
         type: PROBLEM_TYPES.INTERNAL,
       });
     }
-  } catch (error) {
-    if (error instanceof z.ZodError) {
-      return sendProblem(res, 400, 'Invalid request data', {
-        type: PROBLEM_TYPES.VALIDATION,
-        errors: error.errors,
-      });
-    }
-
-    logger.error('Error enhancing question:', error);
-    sendProblem(res, 500, 'Internal server error', {
-      type: PROBLEM_TYPES.INTERNAL,
-    });
-  }
-});
+  })
+);
 
 /**
  * @swagger
@@ -371,17 +384,20 @@ router.post('/enhance/question', async (req: Request, res: Response) => {
  *       200:
  *         description: List of available AI models and capabilities
  */
-router.get('/models', async (req: Request, res: Response) => {
-  try {
-    const models = await mlService.getAvailableModels();
+router.get(
+  '/models',
+  asyncHandler(async (req: Request, res: Response) => {
+    try {
+      const models = await mlService.getAvailableModels();
 
-    res.json(ok(models));
-  } catch (error) {
-    logger.error('Error getting available models:', error);
-    sendProblem(res, 500, 'Failed to get available models', {
-      type: PROBLEM_TYPES.INTERNAL,
-    });
-  }
-});
+      res.json(ok(models));
+    } catch (error) {
+      logger.error('Error getting available models:', error);
+      sendProblem(res, 500, 'Failed to get available models', {
+        type: PROBLEM_TYPES.INTERNAL,
+      });
+    }
+  })
+);
 
 export default router;

--- a/packages/backend/src/utils/asyncHandler.ts
+++ b/packages/backend/src/utils/asyncHandler.ts
@@ -1,0 +1,17 @@
+import { Request, Response, NextFunction, RequestHandler } from 'express';
+
+/**
+ * Wraps an async Express route handler so that any rejected promise or thrown
+ * error is forwarded to the next error-handling middleware instead of becoming
+ * an unhandled Promise rejection.
+ *
+ * Usage:
+ *   router.get('/path', asyncHandler(async (req, res) => { ... }));
+ */
+export function asyncHandler(
+  fn: (req: any, res: Response, next: NextFunction) => Promise<unknown>
+): RequestHandler {
+  return (req: Request, res: Response, next: NextFunction) => {
+    Promise.resolve(fn(req, res, next)).catch(next);
+  };
+}


### PR DESCRIPTION
## Summary
- Adds `packages/backend/src/utils/asyncHandler.ts` — wraps an async handler so any rejected promise/throw calls `next(err)` instead of becoming an unhandled Promise rejection (Express 4 swallows these silently)
- Wraps all 23 async route handlers across 9 files

## Why this matters
Three handlers were already written to `throw` out of catch blocks expecting the error middleware to handle them — but without `asyncHandler` those throws were unhandled Promise rejections:
- `routes/cards.ts` — 5 handlers that re-throw `ValidationError`
- `routes/decks.ts` — 3 handlers that re-throw `ValidationError`

`routes/health.ts` had no try/catch at all — a failure in `ankiConnect.ping()` would crash silently.

The remaining handlers (import, ml, export) had full try/catch — `asyncHandler` is a safety net for them.

## Test plan
- [ ] `tsc` passes with no errors
- [ ] Throwing an error from a deck/card handler now returns an RFC 7807 response instead of hanging

🤖 Generated with [Claude Code](https://claude.com/claude-code)