### PR TITLE
#29 Replace Basic/Cloze magic strings with ANKI_MODELS enum; z.any() → z.unknown()

### DIFF
--- a/apps/cli/src/commands/bundle.ts
+++ b/apps/cli/src/commands/bundle.ts
@@ -9,6 +9,7 @@ import chalk from 'chalk';
 import ora from 'ora';
 import AnkiExport from 'anki-apkg-export';
 import {
+  ANKI_MODELS,
   parseMarkdownCards,
   processJsonCards,
   processRows,
@@ -44,7 +45,7 @@ export async function bundleFile(
     const jsonData = JSON.parse(content);
     processedCards = processJsonCards(jsonData, {
       defaultDeck: options.deck,
-      defaultModel: options.model || 'Basic',
+      defaultModel: options.model || ANKI_MODELS.BASIC,
       defaultTags: options.tags || [],
       dryRun: false,
       validate: true,
@@ -60,7 +61,7 @@ export async function bundleFile(
     });
     processedCards = processRows(rows, {
       defaultDeck: options.deck,
-      defaultModel: options.model || 'Basic',
+      defaultModel: options.model || ANKI_MODELS.BASIC,
       defaultTags: options.tags || [],
       delimiter: ',',
       skipHeader: true,
@@ -77,7 +78,7 @@ export async function bundleFile(
   } else if (ext === '.md' || ext === '.markdown') {
     processedCards = parseMarkdownCards(content, {
       defaultDeck: options.deck,
-      defaultModel: options.model || 'Basic',
+      defaultModel: options.model || ANKI_MODELS.BASIC,
       defaultTags: options.tags || [],
       dryRun: false,
     });

--- a/apps/cli/src/commands/config.ts
+++ b/apps/cli/src/commands/config.ts
@@ -3,7 +3,7 @@ import inquirer from 'inquirer';
 import chalk from 'chalk';
 import { loadConfig, saveConfig, getConfigPath } from '../config';
 import { AnkiClient } from '../anki-client';
-import { ANKI_CONNECT, SERVER } from '@ankiniki/shared';
+import { ANKI_CONNECT, ANKI_MODELS, SERVER } from '@ankiniki/shared';
 
 export function createConfigCommand(): Command {
   const command = new Command('config');
@@ -212,7 +212,7 @@ async function resetConfig(): Promise<void> {
       ankiConnectUrl: ANKI_CONNECT.DEFAULT_URL,
       serverUrl: SERVER.DEFAULT_URL,
       defaultDeck: 'Default',
-      defaultModel: 'Basic',
+      defaultModel: ANKI_MODELS.BASIC,
       debugMode: false,
     });
     console.log(chalk.green('✓ Configuration reset to defaults'));

--- a/apps/cli/src/commands/import.ts
+++ b/apps/cli/src/commands/import.ts
@@ -9,6 +9,7 @@ import axios from 'axios';
 import FormData from 'form-data';
 import { loadConfig } from '../config';
 import { BackendManager } from '../backend-manager';
+import { ANKI_MODELS } from '@ankiniki/shared';
 
 type ImportFormat = 'csv' | 'json' | 'markdown';
 
@@ -43,7 +44,7 @@ export const importCommand = new Command('import')
   )
   .option('-d, --delimiter <delimiter>', 'CSV delimiter', ',')
   .option('--deck <deck>', 'Default deck name')
-  .option('--model <model>', 'Default card model', 'Basic')
+  .option('--model <model>', 'Default card model', ANKI_MODELS.BASIC)
   .option('--tags <tags>', 'Default tags (comma-separated)')
   .option('-p, --preview', 'Preview import without creating cards')
   .option('--dry-run', "Dry run - validate but don't create cards")
@@ -101,7 +102,7 @@ async function importCsv(
   const csvOptions = {
     delimiter: options.delimiter || ',',
     defaultDeck: options.deck,
-    defaultModel: options.model || 'Basic',
+    defaultModel: options.model || ANKI_MODELS.BASIC,
     defaultTags: options.tags ? options.tags.split(',').map(t => t.trim()) : [],
     dryRun: options.preview || options.dryRun || false,
     columnMapping: {
@@ -153,7 +154,7 @@ async function importJson(
 
   const jsonOptions = {
     defaultDeck: options.deck,
-    defaultModel: options.model || 'Basic',
+    defaultModel: options.model || ANKI_MODELS.BASIC,
     defaultTags: options.tags ? options.tags.split(',').map(t => t.trim()) : [],
     dryRun: options.preview || options.dryRun || false,
     validate: true,
@@ -185,7 +186,7 @@ async function importMarkdown(
 
   const mdOptions = {
     defaultDeck: options.deck,
-    defaultModel: options.model || 'Basic',
+    defaultModel: options.model || ANKI_MODELS.BASIC,
     defaultTags: options.tags ? options.tags.split(',').map(t => t.trim()) : [],
     dryRun: options.preview || options.dryRun || false,
   };

--- a/apps/cli/src/config.ts
+++ b/apps/cli/src/config.ts
@@ -1,7 +1,7 @@
 import { homedir } from 'os';
 import { join } from 'path';
 import { readFileSync, writeFileSync, existsSync } from 'fs-extra';
-import { CLI, ANKI_CONNECT, SERVER } from '@ankiniki/shared';
+import { CLI, ANKI_CONNECT, ANKI_MODELS, SERVER } from '@ankiniki/shared';
 
 export interface CliConfig {
   ankiConnectUrl: string;
@@ -17,7 +17,7 @@ const DEFAULT_CONFIG: CliConfig = {
   ankiConnectUrl: ANKI_CONNECT.DEFAULT_URL,
   serverUrl: SERVER.DEFAULT_URL,
   defaultDeck: 'Default',
-  defaultModel: 'Basic',
+  defaultModel: ANKI_MODELS.BASIC,
   debugMode: false,
 };
 

--- a/apps/vscode-extension/src/services/configuration.ts
+++ b/apps/vscode-extension/src/services/configuration.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { ANKI_CONNECT } from '@ankiniki/shared';
+import { ANKI_CONNECT, ANKI_MODELS } from '@ankiniki/shared';
 
 export interface AnkinikiConfig {
   ankiConnectUrl: string;
@@ -31,7 +31,7 @@ export class ConfigurationManager {
   }
 
   getDefaultModel(): string {
-    return this.getConfiguration().get('defaultModel', 'Basic');
+    return this.getConfiguration().get('defaultModel', ANKI_MODELS.BASIC);
   }
 
   getAutoDetectLanguage(): boolean {

--- a/packages/backend/src/routes/cards.ts
+++ b/packages/backend/src/routes/cards.ts
@@ -1,6 +1,6 @@
 import { Router, Response } from 'express';
 import { z } from 'zod';
-import { ApiResponse, ValidationError } from '@ankiniki/shared';
+import { ApiResponse, ValidationError, ANKI_MODELS } from '@ankiniki/shared';
 import { ankiConnect } from '../services/ankiConnect';
 import mlService from '../services/mlService';
 import { logger } from '../utils/logger';
@@ -12,7 +12,7 @@ const router = Router();
 // Add note/card
 const AddNoteSchema = z.object({
   deckName: z.string().min(1),
-  modelName: z.string().default('Basic'),
+  modelName: z.string().default(ANKI_MODELS.BASIC),
   fields: z.record(z.string()),
   tags: z.array(z.string()).default([]),
 });
@@ -126,7 +126,7 @@ const GenerateAndCreateSchema = z.object({
   content: z.string().min(1, 'Content is required'),
   content_type: z.enum(['code', 'markdown', 'text', 'html']),
   deckName: z.string().min(1, 'Deck name is required'),
-  modelName: z.string().default('Basic'),
+  modelName: z.string().default(ANKI_MODELS.BASIC),
   difficulty_level: z
     .enum(['beginner', 'intermediate', 'advanced'])
     .optional()
@@ -227,10 +227,10 @@ router.post(
 
             // Prepare fields based on model
             const fields: Record<string, string> = {};
-            if (validatedData.modelName === 'Basic') {
+            if (validatedData.modelName === ANKI_MODELS.BASIC) {
               fields['Front'] = front;
               fields['Back'] = card.back;
-            } else if (validatedData.modelName === 'Cloze') {
+            } else if (validatedData.modelName === ANKI_MODELS.CLOZE) {
               // For cloze, put everything in Text field
               fields['Text'] = `${front}\n\n${card.back}`;
             } else {

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -5,6 +5,12 @@ export const ANKI_CONNECT = {
   API_VERSION: 6,
 } as const;
 
+// Anki built-in note type names
+export const ANKI_MODELS = {
+  BASIC: 'Basic',
+  CLOZE: 'Cloze',
+} as const;
+
 // Backend Server configuration
 export const SERVER = {
   DEFAULT_PORT: 3001,

--- a/packages/shared/src/import-parsers.ts
+++ b/packages/shared/src/import-parsers.ts
@@ -4,6 +4,7 @@
  */
 
 import { z } from 'zod';
+import { ANKI_MODELS } from './constants';
 
 // ─── Shared types ─────────────────────────────────────────────────────────────
 
@@ -29,7 +30,7 @@ export interface ProcessedCard {
 export const CsvImportOptionsSchema = z.object({
   delimiter: z.string().optional().default(','),
   defaultDeck: z.string().optional(),
-  defaultModel: z.string().optional().default('Basic'),
+  defaultModel: z.string().optional().default(ANKI_MODELS.BASIC),
   defaultTags: z.array(z.string()).optional().default([]),
   skipHeader: z.boolean().optional().default(true),
   dryRun: z.boolean().optional().default(false),
@@ -117,7 +118,7 @@ export function validateCards(cards: ProcessedCard[]): {
 
 export const JsonImportOptionsSchema = z.object({
   defaultDeck: z.string().optional(),
-  defaultModel: z.string().optional().default('Basic'),
+  defaultModel: z.string().optional().default(ANKI_MODELS.BASIC),
   defaultTags: z.array(z.string()).optional().default([]),
   dryRun: z.boolean().optional().default(false),
   validate: z.boolean().optional().default(true),
@@ -187,7 +188,7 @@ export function processJsonCards(
 
 export const MarkdownImportOptionsSchema = z.object({
   defaultDeck: z.string().optional(),
-  defaultModel: z.string().optional().default('Basic'),
+  defaultModel: z.string().optional().default(ANKI_MODELS.BASIC),
   defaultTags: z.array(z.string()).optional().default([]),
   dryRun: z.boolean().optional().default(false),
 });
@@ -281,7 +282,7 @@ export function mapCardFields(
   back: string,
   model: string
 ): Record<string, string> {
-  if (model === 'Cloze') {
+  if (model === ANKI_MODELS.CLOZE) {
     return { Text: `${front}\n\n${back}` };
   }
   return { Front: front, Back: back };

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -40,13 +40,13 @@ export type Deck = z.infer<typeof DeckSchema>;
 export const AnkiConnectRequestSchema = z.object({
   action: z.string(),
   version: z.number(),
-  params: z.record(z.any()).optional(),
+  params: z.record(z.unknown()).optional(),
 });
 
 export type AnkiConnectRequest = z.infer<typeof AnkiConnectRequestSchema>;
 
 export const AnkiConnectResponseSchema = z.object({
-  result: z.any(),
+  result: z.unknown(),
   error: z.string().nullable(),
 });
 


### PR DESCRIPTION
## Summary
- Adds `ANKI_MODELS = { BASIC: 'Basic', CLOZE: 'Cloze' }` to `packages/shared/src/constants.ts`
- Replaces all ~15 occurrences of the literal strings `'Basic'` and `'Cloze'` across 7 files with `ANKI_MODELS.BASIC` / `ANKI_MODELS.CLOZE`
- Tightens the AnkiConnect Zod schemas: `z.any()` → `z.unknown()` for both request params and response result

## Files changed
| File | Change |
|------|--------|
| `packages/shared/src/constants.ts` | Add `ANKI_MODELS` constant |
| `packages/shared/src/types.ts` | `z.any()` → `z.unknown()` in AnkiConnect schemas |
| `packages/shared/src/import-parsers.ts` | 3 schema defaults + 1 conditional |
| `packages/backend/src/routes/cards.ts` | 2 schema defaults + 2 conditionals |
| `apps/cli/src/config.ts` | Default config value |
| `apps/cli/src/commands/bundle.ts` | 3 fallback values |
| `apps/cli/src/commands/config.ts` | Reset-to-defaults value |
| `apps/cli/src/commands/import.ts` | CLI option default + 3 fallback values |
| `apps/vscode-extension/src/services/configuration.ts` | VS Code config fallback |

## Test plan
- [ ] All 4 packages compile (`tsc` passes)
- [ ] `ankiniki import --model Basic` still works
- [ ] Config reset sets `defaultModel` to `Basic`

🤖 Generated with [Claude Code](https://claude.com/claude-code)