### PR TITLE
#29 Extract deck/model validation into ankiValidation service

### DIFF
--- a/packages/backend/src/routes/cards.ts
+++ b/packages/backend/src/routes/cards.ts
@@ -2,6 +2,10 @@ import { Router, Response } from 'express';
 import { z } from 'zod';
 import { ApiResponse, ValidationError, ANKI_MODELS } from '@ankiniki/shared';
 import { ankiConnect } from '../services/ankiConnect';
+import {
+  assertDeckExists,
+  assertModelExists,
+} from '../services/ankiValidation';
 import mlService from '../services/mlService';
 import { logger } from '../utils/logger';
 import { ok } from '../utils/response';
@@ -25,17 +29,10 @@ router.post(
         req.body
       );
 
-      // Validate deck exists
-      const existingDecks = await ankiConnect.getDeckNames();
-      if (!existingDecks.includes(deckName)) {
-        throw new ValidationError(`Deck '${deckName}' does not exist`);
-      }
-
-      // Validate model exists
-      const existingModels = await ankiConnect.modelNames();
-      if (!existingModels.includes(modelName)) {
-        throw new ValidationError(`Model '${modelName}' does not exist`);
-      }
+      await Promise.all([
+        assertDeckExists(deckName),
+        assertModelExists(modelName),
+      ]);
 
       const noteId = await ankiConnect.addNote(
         deckName,
@@ -166,21 +163,10 @@ router.post(
           programming_language: validatedData.programming_language,
         });
 
-        // Validate deck exists
-        const existingDecks = await ankiConnect.getDeckNames();
-        if (!existingDecks.includes(validatedData.deckName)) {
-          throw new ValidationError(
-            `Deck '${validatedData.deckName}' does not exist`
-          );
-        }
-
-        // Validate model exists
-        const existingModels = await ankiConnect.modelNames();
-        if (!existingModels.includes(validatedData.modelName)) {
-          throw new ValidationError(
-            `Model '${validatedData.modelName}' does not exist`
-          );
-        }
+        await Promise.all([
+          assertDeckExists(validatedData.deckName),
+          assertModelExists(validatedData.modelName),
+        ]);
 
         // Generate cards using ML service
         const mlResult = await mlService.generateCards({

--- a/packages/backend/src/routes/decks.ts
+++ b/packages/backend/src/routes/decks.ts
@@ -2,6 +2,10 @@ import { Router, Response } from 'express';
 import { z } from 'zod';
 import { ApiResponse, ValidationError } from '@ankiniki/shared';
 import { ankiConnect } from '../services/ankiConnect';
+import {
+  assertDeckExists,
+  assertDeckNotExists,
+} from '../services/ankiValidation';
 import { logger } from '../utils/logger';
 import { ok } from '../utils/response';
 import { asyncHandler } from '../utils/asyncHandler';
@@ -33,11 +37,7 @@ router.post(
     try {
       const { name } = CreateDeckSchema.parse(req.body);
 
-      // Check if deck already exists
-      const existingDecks = await ankiConnect.getDeckNames();
-      if (existingDecks.includes(name)) {
-        throw new ValidationError(`Deck '${name}' already exists`);
-      }
+      await assertDeckNotExists(name);
 
       const deckId = await ankiConnect.createDeck(name);
 
@@ -66,11 +66,7 @@ router.delete(
       const { name } = req.params;
       const { deleteCards } = DeleteDeckSchema.parse(req.body);
 
-      // Check if deck exists
-      const existingDecks = await ankiConnect.getDeckNames();
-      if (!existingDecks.includes(name)) {
-        throw new ValidationError(`Deck '${name}' does not exist`);
-      }
+      await assertDeckExists(name);
 
       await ankiConnect.deleteDeck(name, deleteCards);
 

--- a/packages/backend/src/services/ankiValidation.ts
+++ b/packages/backend/src/services/ankiValidation.ts
@@ -1,0 +1,34 @@
+/**
+ * Validation helpers that check Anki state and throw ValidationError on failure.
+ * Use these in route handlers instead of fetching deck/model lists inline.
+ *
+ * Note: import/shared.ts has its own loop-optimised variant (pre-fetches once
+ * before iterating many cards) — don't replace that with these per-call helpers.
+ */
+
+import { ValidationError } from '@ankiniki/shared';
+import { ankiConnect } from './ankiConnect';
+
+/** Throws if the deck does not exist in Anki. */
+export async function assertDeckExists(deckName: string): Promise<void> {
+  const decks = await ankiConnect.getDeckNames();
+  if (!decks.includes(deckName)) {
+    throw new ValidationError(`Deck '${deckName}' does not exist`);
+  }
+}
+
+/** Throws if the deck already exists in Anki. */
+export async function assertDeckNotExists(deckName: string): Promise<void> {
+  const decks = await ankiConnect.getDeckNames();
+  if (decks.includes(deckName)) {
+    throw new ValidationError(`Deck '${deckName}' already exists`);
+  }
+}
+
+/** Throws if the note-type model does not exist in Anki. */
+export async function assertModelExists(modelName: string): Promise<void> {
+  const models = await ankiConnect.modelNames();
+  if (!models.includes(modelName)) {
+    throw new ValidationError(`Model '${modelName}' does not exist`);
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `packages/backend/src/services/ankiValidation.ts` with three helpers:
  - `assertDeckExists(name)` — throws `ValidationError` if deck is missing
  - `assertDeckNotExists(name)` — throws `ValidationError` if deck already exists  
  - `assertModelExists(name)` — throws `ValidationError` if model is missing
- Replaces the repeated inline `getDeckNames()` / `modelNames()` + check pattern in `cards.ts` and `decks.ts`
- Bonus: the two checks in `cards.ts` now run in **parallel** via `Promise.all([assertDeckExists, assertModelExists])` instead of sequentially

## Not changed
`import/shared.ts` keeps its pre-fetch-then-loop approach (fetches deck and model lists once before iterating N cards) — using per-call helpers there would hit AnkiConnect once per card instead of once per batch.

## Test plan
- [ ] `tsc` passes
- [ ] `POST /api/cards` with a missing deck returns 400 ValidationError
- [ ] `POST /api/decks` with an existing deck name returns 400 ValidationError

🤖 Generated with [Claude Code](https://claude.com/claude-code)