### PR TITLE
Centralize AnkiConnect user-facing messages into shared constants

### DIFF
--- a/apps/cli/src/commands/add.ts
+++ b/apps/cli/src/commands/add.ts
@@ -2,6 +2,7 @@ import { Command } from 'commander';
 import inquirer from 'inquirer';
 import chalk from 'chalk';
 import ora from 'ora';
+import { ANKI_MESSAGES } from '@ankiniki/shared';
 import { AnkiClient } from '../anki-client';
 import { loadConfig } from '../config';
 
@@ -22,16 +23,14 @@ export function createAddCommand(): Command {
 
       try {
         // Check connection first
-        const spinner = ora('Connecting to Anki...').start();
+        const spinner = ora(ANKI_MESSAGES.CONNECTING).start();
         const isConnected = await client.ping();
 
         if (!isConnected) {
-          spinner.fail(
-            'Cannot connect to Anki. Make sure Anki is running with AnkiConnect.'
-          );
+          spinner.fail(ANKI_MESSAGES.CANNOT_CONNECT_HINT);
           return;
         }
-        spinner.succeed('Connected to Anki');
+        spinner.succeed(ANKI_MESSAGES.CONNECTED);
 
         let cardData = {
           deck: deck || config.defaultDeck,

--- a/apps/cli/src/commands/config.ts
+++ b/apps/cli/src/commands/config.ts
@@ -3,7 +3,12 @@ import inquirer from 'inquirer';
 import chalk from 'chalk';
 import { loadConfig, saveConfig, getConfigPath } from '../config';
 import { AnkiClient } from '../anki-client';
-import { ANKI_CONNECT, ANKI_MODELS, SERVER } from '@ankiniki/shared';
+import {
+  ANKI_CONNECT,
+  ANKI_MODELS,
+  ANKI_MESSAGES,
+  SERVER,
+} from '@ankiniki/shared';
 
 export function createConfigCommand(): Command {
   const command = new Command('config');
@@ -124,7 +129,7 @@ async function editConfig(): Promise<void> {
     // If we can't connect to Anki, allow basic config editing
     console.log(
       chalk.yellow(
-        '⚠ Cannot connect to Anki. Editing basic configuration only.'
+        `⚠ ${ANKI_MESSAGES.CANNOT_CONNECT}. Editing basic configuration only.`
       )
     );
 

--- a/apps/cli/src/commands/deck.ts
+++ b/apps/cli/src/commands/deck.ts
@@ -6,6 +6,7 @@ import { Command } from 'commander';
 import inquirer from 'inquirer';
 import chalk from 'chalk';
 import ora from 'ora';
+import { ANKI_MESSAGES } from '@ankiniki/shared';
 import { AnkiClient } from '../anki-client';
 
 export function createDeckCommand(): Command {
@@ -19,12 +20,12 @@ export function createDeckCommand(): Command {
     .action(async () => {
       const client = new AnkiClient();
       try {
-        const spinner = ora('Connecting to Anki...').start();
+        const spinner = ora(ANKI_MESSAGES.CONNECTING).start();
         if (!(await client.ping())) {
-          spinner.fail('Cannot connect to Anki');
+          spinner.fail(ANKI_MESSAGES.CANNOT_CONNECT);
           process.exit(1);
         }
-        spinner.succeed('Connected to Anki');
+        spinner.succeed(ANKI_MESSAGES.CONNECTED);
 
         const loadSpinner = ora('Loading decks...').start();
         const deckNames = await client.getDeckNames();
@@ -50,12 +51,12 @@ export function createDeckCommand(): Command {
     .action(async (name: string) => {
       const client = new AnkiClient();
       try {
-        const spinner = ora('Connecting to Anki...').start();
+        const spinner = ora(ANKI_MESSAGES.CONNECTING).start();
         if (!(await client.ping())) {
-          spinner.fail('Cannot connect to Anki');
+          spinner.fail(ANKI_MESSAGES.CANNOT_CONNECT);
           process.exit(1);
         }
-        spinner.succeed('Connected to Anki');
+        spinner.succeed(ANKI_MESSAGES.CONNECTED);
 
         const createSpinner = ora(`Creating deck "${name}"...`).start();
         await client.createDeck(name);
@@ -74,12 +75,12 @@ export function createDeckCommand(): Command {
     .action(async (name: string, options: { force?: boolean }) => {
       const client = new AnkiClient();
       try {
-        const spinner = ora('Connecting to Anki...').start();
+        const spinner = ora(ANKI_MESSAGES.CONNECTING).start();
         if (!(await client.ping())) {
-          spinner.fail('Cannot connect to Anki');
+          spinner.fail(ANKI_MESSAGES.CANNOT_CONNECT);
           process.exit(1);
         }
-        spinner.succeed('Connected to Anki');
+        spinner.succeed(ANKI_MESSAGES.CONNECTED);
 
         // Verify deck exists
         const decks = await client.getDeckNames();

--- a/apps/cli/src/commands/delete.ts
+++ b/apps/cli/src/commands/delete.ts
@@ -6,6 +6,7 @@ import { Command } from 'commander';
 import inquirer from 'inquirer';
 import chalk from 'chalk';
 import ora from 'ora';
+import { ANKI_MESSAGES } from '@ankiniki/shared';
 import { AnkiClient } from '../anki-client';
 
 export function createDeleteCommand(): Command {
@@ -25,12 +26,12 @@ export function createDeleteCommand(): Command {
       }
 
       try {
-        const spinner = ora('Connecting to Anki...').start();
+        const spinner = ora(ANKI_MESSAGES.CONNECTING).start();
         if (!(await client.ping())) {
-          spinner.fail('Cannot connect to Anki');
+          spinner.fail(ANKI_MESSAGES.CANNOT_CONNECT);
           process.exit(1);
         }
-        spinner.succeed('Connected to Anki');
+        spinner.succeed(ANKI_MESSAGES.CONNECTED);
 
         // Fetch note info to show front/back before confirming
         const notes = await client.notesInfo([noteId]);

--- a/apps/cli/src/commands/export.ts
+++ b/apps/cli/src/commands/export.ts
@@ -7,6 +7,7 @@ import fs from 'fs';
 import path from 'path';
 import chalk from 'chalk';
 import ora from 'ora';
+import { ANKI_MESSAGES } from '@ankiniki/shared';
 import { AnkiClient } from '../anki-client';
 
 export function createExportCommand(): Command {
@@ -29,12 +30,12 @@ export function createExportCommand(): Command {
         const client = new AnkiClient();
 
         try {
-          const spinner = ora('Connecting to Anki...').start();
+          const spinner = ora(ANKI_MESSAGES.CONNECTING).start();
           if (!(await client.ping())) {
-            spinner.fail('Cannot connect to Anki');
+            spinner.fail(ANKI_MESSAGES.CANNOT_CONNECT);
             process.exit(1);
           }
-          spinner.succeed('Connected to Anki');
+          spinner.succeed(ANKI_MESSAGES.CONNECTED);
 
           // Verify deck exists
           const decks = await client.getDeckNames();

--- a/apps/cli/src/commands/list.ts
+++ b/apps/cli/src/commands/list.ts
@@ -1,6 +1,7 @@
 import { Command } from 'commander';
 import chalk from 'chalk';
 import ora from 'ora';
+import { ANKI_MESSAGES } from '@ankiniki/shared';
 import { AnkiClient } from '../anki-client';
 
 export function createListCommand(): Command {
@@ -15,14 +16,14 @@ export function createListCommand(): Command {
       const client = new AnkiClient();
 
       try {
-        const spinner = ora('Connecting to Anki...').start();
+        const spinner = ora(ANKI_MESSAGES.CONNECTING).start();
         const isConnected = await client.ping();
 
         if (!isConnected) {
-          spinner.fail('Cannot connect to Anki');
+          spinner.fail(ANKI_MESSAGES.CANNOT_CONNECT);
           return;
         }
-        spinner.succeed('Connected to Anki');
+        spinner.succeed(ANKI_MESSAGES.CONNECTED);
 
         if (options.cards) {
           // List cards in specific deck

--- a/apps/cli/src/commands/study.ts
+++ b/apps/cli/src/commands/study.ts
@@ -2,7 +2,7 @@ import { Command } from 'commander';
 import inquirer from 'inquirer';
 import chalk from 'chalk';
 import ora from 'ora';
-import { shuffleArray } from '@ankiniki/shared';
+import { shuffleArray, ANKI_MESSAGES } from '@ankiniki/shared';
 import { AnkiClient } from '../anki-client';
 
 export function createStudyCommand(): Command {
@@ -17,14 +17,14 @@ export function createStudyCommand(): Command {
       const client = new AnkiClient();
 
       try {
-        const spinner = ora('Connecting to Anki...').start();
+        const spinner = ora(ANKI_MESSAGES.CONNECTING).start();
         const isConnected = await client.ping();
 
         if (!isConnected) {
-          spinner.fail('Cannot connect to Anki');
+          spinner.fail(ANKI_MESSAGES.CANNOT_CONNECT);
           return;
         }
-        spinner.succeed('Connected to Anki');
+        spinner.succeed(ANKI_MESSAGES.CONNECTED);
 
         // Select deck if not provided
         let selectedDeck = deck;

--- a/apps/vscode-extension/src/extension.ts
+++ b/apps/vscode-extension/src/extension.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import { ANKI_MESSAGES } from '@ankiniki/shared';
 import { AnkiConnectClient } from './services/ankiConnect';
 import { ConfigurationManager } from './services/configuration';
 import { NotificationManager } from './services/notifications';
@@ -155,17 +156,15 @@ async function testAnkiConnection() {
   try {
     const isConnected = await ankiClient.ping();
     if (isConnected) {
-      notificationManager.showInfo('✅ Connected to Anki');
+      notificationManager.showInfo(`✅ ${ANKI_MESSAGES.CONNECTED}`);
     } else {
       notificationManager.showWarning(
-        '⚠️ Cannot connect to Anki. Make sure Anki is running with AnkiConnect addon.'
+        `⚠️ ${ANKI_MESSAGES.CANNOT_CONNECT_HINT}`
       );
     }
   } catch (error) {
     console.error('Failed to test Anki connection:', error);
-    notificationManager.showWarning(
-      '⚠️ Cannot connect to Anki. Make sure Anki is running with AnkiConnect addon.'
-    );
+    notificationManager.showWarning(`⚠️ ${ANKI_MESSAGES.CANNOT_CONNECT_HINT}`);
   }
 }
 

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -2,6 +2,7 @@ import { createApp } from './app';
 import { config } from './config';
 import { logger } from './utils/logger';
 import { ankiConnect } from './services/ankiConnect';
+import { ANKI_MESSAGES } from '@ankiniki/shared';
 
 async function startServer() {
   try {
@@ -10,9 +11,7 @@ async function startServer() {
     // Check AnkiConnect connection
     const isAnkiConnected = await ankiConnect.ping();
     if (!isAnkiConnected) {
-      logger.warn(
-        'AnkiConnect is not available. Make sure Anki is running with AnkiConnect addon.'
-      );
+      logger.warn(ANKI_MESSAGES.NOT_AVAILABLE_HINT);
     } else {
       logger.info('Successfully connected to AnkiConnect');
     }

--- a/packages/backend/src/routes/health.ts
+++ b/packages/backend/src/routes/health.ts
@@ -1,4 +1,5 @@
 import { Router } from 'express';
+import { ANKI_MESSAGES } from '@ankiniki/shared';
 import { ankiConnect } from '../services/ankiConnect';
 import { config } from '../config';
 import { ok, sendProblem, PROBLEM_TYPES } from '../utils/response';
@@ -34,7 +35,7 @@ router.get(
     if (ankiConnected) {
       res.status(200).json(ok(healthData, 'All services are healthy'));
     } else {
-      sendProblem(res, 503, 'AnkiConnect is not available', {
+      sendProblem(res, 503, ANKI_MESSAGES.NOT_AVAILABLE, {
         type: PROBLEM_TYPES.ANKI_CONNECT,
         instance: req.path,
         ankiConnect: healthData.ankiConnect,

--- a/packages/shared/src/anki-client.ts
+++ b/packages/shared/src/anki-client.ts
@@ -3,6 +3,7 @@ import {
   AnkiConnectResponse,
   AnkiConnectError,
   ANKI_CONNECT,
+  ANKI_MESSAGES,
 } from './index';
 
 export interface NoteInfo {
@@ -75,7 +76,7 @@ export class AnkiConnectClient {
       }
 
       if (error instanceof DOMException && error.name === 'AbortError') {
-        const msg = 'AnkiConnect request timed out';
+        const msg = ANKI_MESSAGES.REQUEST_TIMEOUT;
         this.logger?.error(msg, { action });
         throw new AnkiConnectError(msg);
       }
@@ -88,8 +89,7 @@ export class AnkiConnectClient {
           cause?.code === 'ECONNREFUSED' ||
           error.message.includes('ECONNREFUSED')
         ) {
-          const msg =
-            'Cannot connect to Anki. Make sure Anki is running and AnkiConnect addon is installed.';
+          const msg = ANKI_MESSAGES.CANNOT_CONNECT_HINT;
           this.logger?.error(msg, { action });
           throw new AnkiConnectError(msg);
         }

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -72,6 +72,19 @@ export const CLI = {
   CONFIG_FILE: '.ankiniki.json',
 } as const;
 
+// User-facing messages for AnkiConnect connectivity
+export const ANKI_MESSAGES = {
+  CONNECTING: 'Connecting to Anki...',
+  CONNECTED: 'Connected to Anki',
+  CANNOT_CONNECT: 'Cannot connect to Anki',
+  CANNOT_CONNECT_HINT:
+    'Cannot connect to Anki. Make sure Anki is running with AnkiConnect addon installed.',
+  NOT_AVAILABLE: 'AnkiConnect is not available',
+  NOT_AVAILABLE_HINT:
+    'AnkiConnect is not available. Make sure Anki is running with AnkiConnect addon installed.',
+  REQUEST_TIMEOUT: 'AnkiConnect request timed out',
+} as const;
+
 // Error codes
 export const ERROR_CODES = {
   ANKI_CONNECT_ERROR: 'ANKI_CONNECT_ERROR',


### PR DESCRIPTION
## Summary

- Add `ANKI_MESSAGES` constant object to `@ankiniki/shared` with keys: `CONNECTING`, `CONNECTED`, `CANNOT_CONNECT`, `CANNOT_CONNECT_HINT`, `NOT_AVAILABLE`, `NOT_AVAILABLE_HINT`, `REQUEST_TIMEOUT`
- Replace all hardcoded connectivity strings across CLI commands (`add`, `config`, `deck`, `delete`, `export`, `list`, `study`), backend (`index.ts`, `routes/health.ts`), VS Code extension, and `anki-client.ts` in shared

## Test plan

- [ ] `npm run type-check` passes (already verified for shared, backend, CLI, and VS Code extension)
- [ ] CLI commands show consistent "Connecting to Anki..." / "Cannot connect to Anki" messages
- [ ] Backend health route returns consistent "AnkiConnect is not available" problem title
- [ ] VS Code extension shows consistent warning when Anki is unreachable

🤖 Generated with [Claude Code](https://claude.com/claude-code)