### PR TITLE
#28 Modernize VS Code extension — generate command, status indicator, bug fix

### DIFF
--- a/apps/vscode-extension/package.json
+++ b/apps/vscode-extension/package.json
@@ -50,6 +50,11 @@
         "category": "Ankiniki"
       },
       {
+        "command": "ankiniki.generateFromFile",
+        "title": "Generate Flashcards from Current File (AI)",
+        "category": "Ankiniki"
+      },
+      {
         "command": "ankiniki.openSettings",
         "title": "Open Settings",
         "category": "Ankiniki"
@@ -85,6 +90,11 @@
           "command": "ankiniki.addCodeBlock",
           "when": "editorTextFocus",
           "group": "ankiniki@2"
+        },
+        {
+          "command": "ankiniki.generateFromFile",
+          "when": "editorTextFocus",
+          "group": "ankiniki@3"
         }
       ],
       "commandPalette": [
@@ -105,6 +115,11 @@
           "type": "string",
           "default": "http://localhost:8765",
           "description": "AnkiConnect server URL"
+        },
+        "ankiniki.serverUrl": {
+          "type": "string",
+          "default": "http://localhost:3001",
+          "description": "Ankiniki backend server URL (used for AI card generation)"
         },
         "ankiniki.defaultDeck": {
           "type": "string",

--- a/apps/vscode-extension/src/extension.ts
+++ b/apps/vscode-extension/src/extension.ts
@@ -24,7 +24,11 @@ export function activate(context: vscode.ExtensionContext) {
     configManager,
     notificationManager
   );
-  sidebarProvider = new SidebarProvider(context.extensionUri, cardService);
+  sidebarProvider = new SidebarProvider(
+    context.extensionUri,
+    cardService,
+    ankiClient
+  );
 
   // Set context for conditional UI elements
   vscode.commands.executeCommand('setContext', 'ankiniki.enabled', true);
@@ -52,6 +56,10 @@ export function activate(context: vscode.ExtensionContext) {
         'workbench.action.openSettings',
         'ankiniki'
       );
+    }),
+
+    vscode.commands.registerCommand('ankiniki.generateFromFile', () => {
+      handleGenerateFromFile();
     }),
 
     vscode.commands.registerCommand('ankiniki.refresh', () => {
@@ -150,6 +158,25 @@ async function handleQuickAdd() {
   }
 
   await cardService.createQuickCard(front, back);
+}
+
+async function handleGenerateFromFile() {
+  const editor = vscode.window.activeTextEditor;
+  if (!editor) {
+    notificationManager.showError('No active editor — open a file first');
+    return;
+  }
+
+  const content = editor.document.getText();
+  if (!content.trim()) {
+    notificationManager.showError('File is empty');
+    return;
+  }
+
+  const language = editor.document.languageId;
+  const filePath = vscode.workspace.asRelativePath(editor.document.fileName);
+
+  await cardService.generateCardsFromFile(content, language, filePath);
 }
 
 async function testAnkiConnection() {

--- a/apps/vscode-extension/src/providers/sidebarProvider.ts
+++ b/apps/vscode-extension/src/providers/sidebarProvider.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import { CardCreationService } from '../services/cardCreation';
+import { AnkiConnectClient } from '../services/ankiConnect';
 
 export class SidebarProvider implements vscode.WebviewViewProvider {
   public static readonly viewType = 'ankinikiSidebar';
@@ -8,7 +9,8 @@ export class SidebarProvider implements vscode.WebviewViewProvider {
 
   constructor(
     private readonly _extensionUri: vscode.Uri,
-    private readonly cardService: CardCreationService
+    private readonly cardService: CardCreationService,
+    private readonly ankiClient: AnkiConnectClient
   ) {}
 
   public resolveWebviewView(
@@ -36,10 +38,18 @@ export class SidebarProvider implements vscode.WebviewViewProvider {
         case 'addCode':
           vscode.commands.executeCommand('ankiniki.addCodeBlock');
           break;
+        case 'generateFromFile':
+          vscode.commands.executeCommand('ankiniki.generateFromFile');
+          break;
         case 'openSettings':
           vscode.commands.executeCommand('ankiniki.openSettings');
           break;
       }
+    });
+
+    // Check AnkiConnect status and push it to the webview
+    this.ankiClient.ping().then(connected => {
+      this._view?.webview.postMessage({ type: 'status', connected });
     });
   }
 
@@ -49,153 +59,82 @@ export class SidebarProvider implements vscode.WebviewViewProvider {
     }
   }
 
-  private _getHtmlForWebview(webview: vscode.Webview) {
+  private _getHtmlForWebview(_webview: vscode.Webview) {
     return `<!DOCTYPE html>
-			<html lang="en">
-			<head>
-				<meta charset="UTF-8">
-				<meta name="viewport" content="width=device-width, initial-scale=1.0">
-				<title>Ankiniki</title>
-				<style>
-					body {
-						font-family: var(--vscode-font-family);
-						color: var(--vscode-foreground);
-						background-color: var(--vscode-editor-background);
-						padding: 16px;
-					}
-					
-					.header {
-						margin-bottom: 20px;
-						text-align: center;
-					}
-					
-					.header h2 {
-						margin: 0 0 8px 0;
-						color: var(--vscode-titleBar-activeForeground);
-					}
-					
-					.header p {
-						margin: 0;
-						color: var(--vscode-descriptionForeground);
-						font-size: 12px;
-					}
-					
-					.quick-actions {
-						margin-bottom: 24px;
-					}
-					
-					.quick-actions h3 {
-						margin: 0 0 12px 0;
-						font-size: 14px;
-						color: var(--vscode-titleBar-activeForeground);
-					}
-					
-					.action-button {
-						display: block;
-						width: 100%;
-						padding: 8px 12px;
-						margin-bottom: 8px;
-						background-color: var(--vscode-button-background);
-						color: var(--vscode-button-foreground);
-						border: none;
-						border-radius: 3px;
-						cursor: pointer;
-						font-size: 13px;
-						text-align: left;
-					}
-					
-					.action-button:hover {
-						background-color: var(--vscode-button-hoverBackground);
-					}
-					
-					.action-button:last-child {
-						margin-bottom: 0;
-					}
-					
-					.settings-section {
-						border-top: 1px solid var(--vscode-panel-border);
-						padding-top: 16px;
-					}
-					
-					.settings-button {
-						background-color: var(--vscode-button-secondaryBackground);
-						color: var(--vscode-button-secondaryForeground);
-					}
-					
-					.settings-button:hover {
-						background-color: var(--vscode-button-secondaryHoverBackground);
-					}
-					
-					.icon {
-						margin-right: 8px;
-					}
-					
-					.status {
-						margin-top: 16px;
-						padding: 8px 12px;
-						background-color: var(--vscode-inputValidation-infoBackground);
-						border-left: 3px solid var(--vscode-inputValidation-infoBorder);
-						border-radius: 3px;
-						font-size: 12px;
-					}
-				</style>
-			</head>
-			<body>
-				<div class="header">
-					<h2>📚 Ankiniki</h2>
-					<p>Create Anki flashcards from VS Code</p>
-				</div>
-				
-				<div class="quick-actions">
-					<h3>Quick Actions</h3>
-					
-					<button class="action-button" onclick="addSelected()">
-						<span class="icon">📝</span>
-						Add Selected Text
-					</button>
-					
-					<button class="action-button" onclick="addCode()">
-						<span class="icon">💻</span>
-						Add Code Block
-					</button>
-					
-					<button class="action-button" onclick="quickAdd()">
-						<span class="icon">⚡</span>
-						Quick Add Card
-					</button>
-				</div>
-				
-				<div class="settings-section">
-					<button class="action-button settings-button" onclick="openSettings()">
-						<span class="icon">⚙️</span>
-						Settings
-					</button>
-				</div>
-				
-				<div class="status">
-					💡 <strong>Tip:</strong> Select text and use <kbd>Ctrl+Shift+A</kbd> to quickly create a flashcard
-				</div>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Ankiniki</title>
+  <style>
+    body { font-family: var(--vscode-font-family); color: var(--vscode-foreground); background: var(--vscode-editor-background); padding: 12px; }
+    .header { margin-bottom: 16px; text-align: center; }
+    .header h2 { margin: 0 0 4px 0; color: var(--vscode-titleBar-activeForeground); }
+    .header p { margin: 0; color: var(--vscode-descriptionForeground); font-size: 12px; }
+    .conn-status { margin-bottom: 14px; padding: 6px 10px; border-radius: 3px; font-size: 12px; border-left: 3px solid; }
+    .conn-checking { background: var(--vscode-inputValidation-infoBackground); border-color: var(--vscode-inputValidation-infoBorder); }
+    .conn-ok  { background: var(--vscode-inputValidation-infoBackground); border-color: var(--vscode-testing-iconPassed, #73c991); }
+    .conn-err { background: var(--vscode-inputValidation-errorBackground); border-color: var(--vscode-inputValidation-errorBorder); }
+    h3 { margin: 0 0 10px 0; font-size: 13px; color: var(--vscode-titleBar-activeForeground); }
+    .action-button { display: block; width: 100%; padding: 7px 10px; margin-bottom: 7px; background: var(--vscode-button-background); color: var(--vscode-button-foreground); border: none; border-radius: 3px; cursor: pointer; font-size: 13px; text-align: left; }
+    .action-button:hover { background: var(--vscode-button-hoverBackground); }
+    .generate-button { background: var(--vscode-button-secondaryBackground); color: var(--vscode-button-secondaryForeground); margin-top: 4px; }
+    .generate-button:hover { background: var(--vscode-button-secondaryHoverBackground); }
+    .settings-section { border-top: 1px solid var(--vscode-panel-border); padding-top: 12px; margin-top: 12px; }
+    .settings-button { background: transparent; color: var(--vscode-descriptionForeground); border: 1px solid var(--vscode-panel-border); }
+    .settings-button:hover { background: var(--vscode-list-hoverBackground); }
+    .tip { margin-top: 14px; padding: 6px 10px; background: var(--vscode-textBlockQuote-background); border-left: 3px solid var(--vscode-textBlockQuote-border); font-size: 11px; }
+  </style>
+</head>
+<body>
+  <div class="header">
+    <h2>📚 Ankiniki</h2>
+    <p>Create Anki flashcards from VS Code</p>
+  </div>
 
-				<script>
-					const vscode = acquireVsCodeApi();
+  <div id="conn" class="conn-status conn-checking">⏳ Checking Anki connection…</div>
 
-					function quickAdd() {
-						vscode.postMessage({ type: 'quickAdd' });
-					}
+  <div class="quick-actions">
+    <h3>Quick Actions</h3>
+    <button class="action-button" onclick="addSelected()">📝&nbsp; Add Selected Text</button>
+    <button class="action-button" onclick="addCode()">💻&nbsp; Add Code Block</button>
+    <button class="action-button" onclick="quickAdd()">⚡&nbsp; Quick Add Card</button>
+    <button class="action-button generate-button" onclick="generateFromFile()">🤖&nbsp; Generate from Current File (AI)</button>
+  </div>
 
-					function addSelected() {
-						vscode.postMessage({ type: 'addSelected' });
-					}
+  <div class="settings-section">
+    <button class="action-button settings-button" onclick="openSettings()">⚙️&nbsp; Settings</button>
+  </div>
 
-					function addCode() {
-						vscode.postMessage({ type: 'addCode' });
-					}
+  <div class="tip">
+    💡 Select text → <kbd>Ctrl+Shift+A</kbd> to create a flashcard instantly
+  </div>
 
-					function openSettings() {
-						vscode.postMessage({ type: 'openSettings' });
-					}
-				</script>
-			</body>
-			</html>`;
+  <script>
+    const vscode = acquireVsCodeApi();
+    function quickAdd()        { vscode.postMessage({ type: 'quickAdd' }); }
+    function addSelected()     { vscode.postMessage({ type: 'addSelected' }); }
+    function addCode()         { vscode.postMessage({ type: 'addCode' }); }
+    function generateFromFile(){ vscode.postMessage({ type: 'generateFromFile' }); }
+    function openSettings()    { vscode.postMessage({ type: 'openSettings' }); }
+
+    window.addEventListener('message', e => {
+      const msg = e.data;
+      if (msg.type === 'status') {
+        const el = document.getElementById('conn');
+        if (el) {
+          if (msg.connected) {
+            el.className = 'conn-status conn-ok';
+            el.textContent = '✓ Connected to Anki';
+          } else {
+            el.className = 'conn-status conn-err';
+            el.textContent = '✗ Cannot reach Anki — open Anki with AnkiConnect installed';
+          }
+        }
+      }
+    });
+  </script>
+</body>
+</html>`;
   }
 }

--- a/apps/vscode-extension/src/services/cardCreation.ts
+++ b/apps/vscode-extension/src/services/cardCreation.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import { ANKI_MODELS } from '@ankiniki/shared';
 import { AnkiConnectClient } from './ankiConnect';
 import { ConfigurationManager } from './configuration';
 import { NotificationManager } from './notifications';
@@ -157,6 +158,167 @@ export class CardCreationService {
     }
   }
 
+  async generateCardsFromFile(
+    content: string,
+    language: string,
+    filePath: string
+  ): Promise<void> {
+    const serverUrl = this.config.getServerUrl();
+    const defaultDeck = this.config.getDefaultDeck();
+
+    // Map VS Code language IDs to content types
+    const codeLanguages = new Set([
+      'javascript',
+      'typescript',
+      'javascriptreact',
+      'typescriptreact',
+      'python',
+      'java',
+      'cpp',
+      'c',
+      'go',
+      'rust',
+      'ruby',
+      'php',
+      'swift',
+      'kotlin',
+      'scala',
+      'csharp',
+    ]);
+    const contentType =
+      language === 'markdown'
+        ? 'markdown'
+        : codeLanguages.has(language)
+          ? 'code'
+          : 'text';
+
+    interface GeneratedCard {
+      front: string;
+      back: string;
+      tags: string[];
+      difficulty: string;
+      confidence_score: number;
+    }
+
+    try {
+      // Step 1 — generate cards via backend ML service
+      const generated = await this.notifications.showProgress(
+        'Ankiniki: Generating cards with AI…',
+        async () => {
+          const response = await fetch(`${serverUrl}/api/ml/generate/cards`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              content,
+              content_type: contentType,
+              difficulty_level: 'intermediate',
+              max_cards: 10,
+              ...(codeLanguages.has(language)
+                ? { programming_language: language }
+                : {}),
+            }),
+          });
+
+          if (!response.ok) {
+            const err = (await response.json().catch(() => ({}))) as {
+              detail?: string;
+            };
+            throw new Error(err.detail ?? `HTTP ${response.status}`);
+          }
+
+          const body = (await response.json()) as {
+            success: boolean;
+            data: { success: boolean; cards: GeneratedCard[] };
+            detail?: string;
+          };
+
+          if (!body.success) {
+            throw new Error(body.detail ?? 'Generation failed');
+          }
+
+          return body.data?.cards ?? [];
+        }
+      );
+
+      if (!generated.length) {
+        this.notifications.showWarning(
+          'No cards were generated for this file.'
+        );
+        return;
+      }
+
+      // Step 2 — let user pick which cards to keep
+      const picks = generated.map((card, i) => ({
+        label: `$(lightbulb) ${card.front.slice(0, 80)}${card.front.length > 80 ? '…' : ''}`,
+        description: `${Math.round(card.confidence_score * 100)}% confidence · ${card.difficulty}`,
+        detail: card.back.slice(0, 120),
+        picked: card.confidence_score >= 0.6,
+        card,
+        index: i,
+      }));
+
+      const selected = await vscode.window.showQuickPick(picks, {
+        canPickMany: true,
+        placeHolder: `Select cards to add to Anki (${generated.length} generated from ${filePath})`,
+        title: 'AI-Generated Flashcards',
+      });
+
+      if (!selected || selected.length === 0) {
+        return;
+      }
+
+      // Step 3 — ensure deck and add selected cards
+      const availableDecks = await this.ankiClient.getDeckNames();
+      let targetDeck = defaultDeck;
+      if (!availableDecks.includes(defaultDeck)) {
+        const pick = await this.notifications.showQuickPick(
+          availableDecks.map(d => ({ label: d, description: d })),
+          { placeHolder: 'Select target deck' }
+        );
+        if (!pick) {
+          return;
+        }
+        targetDeck = pick.label;
+      }
+
+      let added = 0;
+      let failed = 0;
+      for (const item of selected) {
+        try {
+          const allTags = [
+            ...item.card.tags,
+            'ai-generated',
+            `difficulty-${item.card.difficulty}`,
+            'vscode',
+          ];
+          if (codeLanguages.has(language)) {
+            allTags.push(language);
+          }
+          await this.ankiClient.addNote(
+            targetDeck,
+            ANKI_MODELS.BASIC,
+            { Front: item.card.front, Back: item.card.back },
+            allTags
+          );
+          added++;
+        } catch {
+          failed++;
+        }
+      }
+
+      const msg = `Added ${added} AI-generated card(s) to "${targetDeck}"${failed > 0 ? ` (${failed} failed)` : ''}`;
+      if (failed > 0) {
+        this.notifications.showWarning(msg);
+      } else {
+        this.notifications.showInfo(msg);
+      }
+    } catch (error) {
+      this.notifications.showError(
+        `Failed to generate cards: ${(error as Error).message}`
+      );
+    }
+  }
+
   private async createCard(
     deck: string,
     front: string,
@@ -166,7 +328,7 @@ export class CardCreationService {
     const model = this.config.getDefaultModel();
 
     // Get field names for the model
-    const fieldNames = await this.ankiClient.getModelFieldNames(model);
+    const fieldNames = await this.ankiClient.modelFieldNames(model);
 
     // Map to AnkiConnect fields format
     const fields: Record<string, string> = {};

--- a/apps/vscode-extension/src/services/configuration.ts
+++ b/apps/vscode-extension/src/services/configuration.ts
@@ -1,8 +1,9 @@
 import * as vscode from 'vscode';
-import { ANKI_CONNECT, ANKI_MODELS } from '@ankiniki/shared';
+import { ANKI_CONNECT, ANKI_MODELS, SERVER } from '@ankiniki/shared';
 
 export interface AnkinikiConfig {
   ankiConnectUrl: string;
+  serverUrl: string;
   defaultDeck: string;
   defaultModel: string;
   autoDetectLanguage: boolean;
@@ -24,6 +25,10 @@ export class ConfigurationManager {
       'ankiConnectUrl',
       ANKI_CONNECT.DEFAULT_URL
     );
+  }
+
+  getServerUrl(): string {
+    return this.getConfiguration().get('serverUrl', SERVER.DEFAULT_URL);
   }
 
   getDefaultDeck(): string {
@@ -49,6 +54,7 @@ export class ConfigurationManager {
   getAllConfig(): AnkinikiConfig {
     return {
       ankiConnectUrl: this.getAnkiConnectUrl(),
+      serverUrl: this.getServerUrl(),
       defaultDeck: this.getDefaultDeck(),
       defaultModel: this.getDefaultModel(),
       autoDetectLanguage: this.getAutoDetectLanguage(),


### PR DESCRIPTION
## Summary

Three changes for issue #28.

### Bug fix
`cardCreation.ts` was calling `this.ankiClient.getModelFieldNames()` which doesn't exist on `AnkiConnectClient` (the correct method is `modelFieldNames`). Every card creation via the extension would throw at runtime. Fixed.

### New: Generate Flashcards from Current File (AI)

New `ankiniki.generateFromFile` command available from:
- Editor context menu (right-click → Ankiniki)
- Sidebar "Generate from Current File (AI)" button
- Command Palette

Flow:
1. Reads the active editor's content and language ID
2. Maps language to `code` / `markdown` / `text` content type
3. Calls `POST /api/ml/generate/cards` on the backend (shown as VS Code progress notification)
4. Presents results as a **multi-select QuickPick** — cards ≥60% confidence pre-checked, with confidence% and difficulty shown as description
5. Adds selected cards to Anki with `ai-generated`, `difficulty-*`, `vscode`, and language tags

Requires the backend to be running (`ankiniki status` to check). New `ankiniki.serverUrl` setting (default `http://localhost:3001`).

### Sidebar improvements
- **Connection status badge** at the top: pings AnkiConnect when the panel opens, shows green ✓ or red ✗ with a fix hint
- Cleaner button layout, refined styles using VS Code CSS variables
- "Generate from File (AI)" button added

## Test plan

- [ ] Right-click in any editor → Ankiniki → Generate Flashcards from Current File (AI) → progress shown → QuickPick appears → selected cards added to Anki
- [ ] Creating a card via "Add Selected Text" no longer crashes (getModelFieldNames bug fixed)
- [ ] Sidebar shows green ✓ when Anki is running, red ✗ when not
- [ ] `ankiniki.serverUrl` setting visible in VS Code settings UI
- [ ] TypeScript: `npx tsc -p apps/vscode-extension/tsconfig.json --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)