### PR TITLE
Add backend route tests + fix DELETE /api/decks/:name schema bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1561,6 +1561,19 @@
         "@emnapi/runtime": "^1.7.1"
       }
     },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "dev": true,
@@ -1601,6 +1614,16 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@paralleldrive/cuid2": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.3.1.tgz",
+      "integrity": "sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^1.1.5"
       }
     },
     "node_modules/@pkgjs/parseargs": {
@@ -2046,6 +2069,13 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/cookiejar": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.5.tgz",
+      "integrity": "sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/cors": {
       "version": "2.8.19",
       "dev": true,
@@ -2176,6 +2206,13 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/methods": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@types/methods/-/methods-1.1.4.tgz",
+      "integrity": "sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/mime": {
       "version": "1.3.5",
       "dev": true,
@@ -2280,6 +2317,30 @@
       "version": "2.0.3",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/superagent": {
+      "version": "8.1.9",
+      "resolved": "https://registry.npmjs.org/@types/superagent/-/superagent-8.1.9.tgz",
+      "integrity": "sha512-pTVjI73witn+9ILmoJdajHGW2jkSaOzhiFYF1Rd3EQ94kymLqB9PjD9ISg7WaALC7+dCHT0FGe9T2LktLq/3GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/cookiejar": "^2.1.5",
+        "@types/methods": "^1.1.4",
+        "@types/node": "*",
+        "form-data": "^4.0.0"
+      }
+    },
+    "node_modules/@types/supertest": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@types/supertest/-/supertest-7.2.0.tgz",
+      "integrity": "sha512-uh2Lv57xvggst6lCqNdFAmDSvoMG7M/HDtX4iUCquxQ5EGPtaPM5PL5Hmi7LCvOG8db7YaCPNJEeoI8s/WzIQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/methods": "^1.1.4",
+        "@types/superagent": "^8.1.0"
+      }
     },
     "node_modules/@types/through": {
       "version": "0.0.33",
@@ -3047,6 +3108,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/assertion-error": {
       "version": "2.0.1",
@@ -3978,6 +4046,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/component-emitter": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
+      "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "dev": true,
@@ -4215,6 +4293,13 @@
     },
     "node_modules/cookie-signature": {
       "version": "1.0.6",
+      "license": "MIT"
+    },
+    "node_modules/cookiejar": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/core-util-is": {
@@ -4576,6 +4661,17 @@
       "dev": true,
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/dezalgo": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
+      }
     },
     "node_modules/diff-sequences": {
       "version": "29.6.3",
@@ -6112,6 +6208,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fast-uri": {
       "version": "3.1.0",
       "funding": [
@@ -6349,6 +6452,24 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/formidable": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.4.tgz",
+      "integrity": "sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@paralleldrive/cuid2": "^2.2.2",
+        "dezalgo": "^1.0.4",
+        "once": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/tunnckoCore/commissions"
       }
     },
     "node_modules/forwarded": {
@@ -11759,6 +11880,68 @@
         "node": ">= 8.0"
       }
     },
+    "node_modules/superagent": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-10.3.0.tgz",
+      "integrity": "sha512-B+4Ik7ROgVKrQsXTV0Jwp2u+PXYLSlqtDAhYnkkD+zn3yg8s/zjA2MeGayPoY/KICrbitwneDHrjSotxKL+0XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "component-emitter": "^1.3.1",
+        "cookiejar": "^2.1.4",
+        "debug": "^4.3.7",
+        "fast-safe-stringify": "^2.1.1",
+        "form-data": "^4.0.5",
+        "formidable": "^3.5.4",
+        "methods": "^1.1.2",
+        "mime": "2.6.0",
+        "qs": "^6.14.1"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/superagent/node_modules/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/supertest": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-7.2.2.tgz",
+      "integrity": "sha512-oK8WG9diS3DlhdUkcFn4tkNIiIbBx9lI2ClF8K+b2/m8Eyv47LSawxUzZQSNKUrVb2KsqeTDCcjAAVPYaSLVTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cookie-signature": "^1.2.2",
+        "methods": "^1.1.2",
+        "superagent": "^10.3.0"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/supertest/node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "license": "MIT",
@@ -13299,7 +13482,9 @@
         "@types/morgan": "^1.9.4",
         "@types/multer": "^1.4.7",
         "@types/node": "^20.5.0",
+        "@types/supertest": "^7.2.0",
         "jest": "^29.6.2",
+        "supertest": "^7.2.2",
         "typescript": "^5.1.6",
         "vitest": "^4.1.2"
       }

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -30,7 +30,9 @@
     "@types/morgan": "^1.9.4",
     "@types/multer": "^1.4.7",
     "@types/node": "^20.5.0",
+    "@types/supertest": "^7.2.0",
     "jest": "^29.6.2",
+    "supertest": "^7.2.2",
     "typescript": "^5.1.6",
     "vitest": "^4.1.2"
   }

--- a/packages/backend/src/__tests__/cards.test.ts
+++ b/packages/backend/src/__tests__/cards.test.ts
@@ -1,0 +1,217 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import request from 'supertest';
+import { createApp } from '../app';
+import { ankiConnect } from '../services/ankiConnect';
+
+vi.mock('../services/ankiConnect', () => ({
+  ankiConnect: {
+    ping: vi.fn(),
+    getDeckNames: vi.fn(),
+    createDeck: vi.fn(),
+    deleteDeck: vi.fn(),
+    addNote: vi.fn(),
+    updateNoteFields: vi.fn(),
+    deleteNotes: vi.fn(),
+    findNotes: vi.fn(),
+    notesInfo: vi.fn(),
+    modelNames: vi.fn(),
+    ensureDeckExists: vi.fn(),
+  },
+}));
+
+// generateCards used by POST /api/cards/generate-and-create
+vi.mock('../services/mlService', () => ({
+  default: {
+    generateCards: vi.fn(),
+    enhanceQuestion: vi.fn(),
+    getAvailability: vi.fn().mockReturnValue(true),
+  },
+}));
+
+const app = createApp();
+
+describe('Cards API', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('POST /api/cards', () => {
+    it('creates a note and returns 201 with noteId', async () => {
+      vi.mocked(ankiConnect.getDeckNames).mockResolvedValue(['Default']);
+      vi.mocked(ankiConnect.modelNames).mockResolvedValue(['Basic']);
+      vi.mocked(ankiConnect.addNote).mockResolvedValue(12345);
+
+      const res = await request(app)
+        .post('/api/cards')
+        .send({
+          deckName: 'Default',
+          modelName: 'Basic',
+          fields: {
+            Front: 'What is TypeScript?',
+            Back: 'A typed superset of JS',
+          },
+          tags: ['typescript'],
+        });
+
+      expect(res.status).toBe(201);
+      expect(res.body.success).toBe(true);
+      expect(res.body.data.noteId).toBe(12345);
+      expect(ankiConnect.addNote).toHaveBeenCalledWith(
+        'Default',
+        'Basic',
+        { Front: 'What is TypeScript?', Back: 'A typed superset of JS' },
+        ['typescript']
+      );
+    });
+
+    it('uses Basic model as default when modelName is omitted', async () => {
+      vi.mocked(ankiConnect.getDeckNames).mockResolvedValue(['Default']);
+      vi.mocked(ankiConnect.modelNames).mockResolvedValue(['Basic']);
+      vi.mocked(ankiConnect.addNote).mockResolvedValue(99);
+
+      const res = await request(app)
+        .post('/api/cards')
+        .send({
+          deckName: 'Default',
+          fields: { Front: 'Q', Back: 'A' },
+        });
+
+      expect(res.status).toBe(201);
+      expect(ankiConnect.addNote).toHaveBeenCalledWith(
+        'Default',
+        'Basic',
+        expect.any(Object),
+        []
+      );
+    });
+
+    it('returns 400 when deckName is missing', async () => {
+      const res = await request(app)
+        .post('/api/cards')
+        .send({
+          fields: { Front: 'Q', Back: 'A' },
+        });
+
+      expect(res.status).toBe(400);
+      expect(res.type).toMatch(/problem\+json/);
+      expect(res.body.type).toBe('/problems/validation-error');
+    });
+
+    it('returns 400 when deck does not exist in Anki', async () => {
+      vi.mocked(ankiConnect.getDeckNames).mockResolvedValue(['Other']);
+      vi.mocked(ankiConnect.modelNames).mockResolvedValue(['Basic']);
+
+      const res = await request(app)
+        .post('/api/cards')
+        .send({
+          deckName: 'NonExistent',
+          fields: { Front: 'Q', Back: 'A' },
+        });
+
+      expect(res.status).toBe(400);
+      expect(res.type).toMatch(/problem\+json/);
+      expect(ankiConnect.addNote).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 when model does not exist in Anki', async () => {
+      vi.mocked(ankiConnect.getDeckNames).mockResolvedValue(['Default']);
+      vi.mocked(ankiConnect.modelNames).mockResolvedValue(['Cloze']); // Basic not available
+
+      const res = await request(app)
+        .post('/api/cards')
+        .send({
+          deckName: 'Default',
+          modelName: 'Basic',
+          fields: { Front: 'Q', Back: 'A' },
+        });
+
+      expect(res.status).toBe(400);
+      expect(res.type).toMatch(/problem\+json/);
+      expect(ankiConnect.addNote).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('PUT /api/cards', () => {
+    it('updates note fields and returns 200', async () => {
+      vi.mocked(ankiConnect.updateNoteFields).mockResolvedValue(undefined);
+
+      const res = await request(app)
+        .put('/api/cards')
+        .send({
+          noteId: 12345,
+          fields: { Front: 'Updated question' },
+        });
+
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(ankiConnect.updateNoteFields).toHaveBeenCalledWith(12345, {
+        Front: 'Updated question',
+      });
+    });
+
+    it('returns 400 when noteId is missing', async () => {
+      const res = await request(app)
+        .put('/api/cards')
+        .send({
+          fields: { Front: 'Q' },
+        });
+
+      expect(res.status).toBe(400);
+      expect(res.type).toMatch(/problem\+json/);
+    });
+  });
+
+  describe('DELETE /api/cards', () => {
+    it('deletes notes and returns 200', async () => {
+      vi.mocked(ankiConnect.deleteNotes).mockResolvedValue(undefined);
+
+      const res = await request(app)
+        .delete('/api/cards')
+        .send({ noteIds: [1, 2, 3] });
+
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(ankiConnect.deleteNotes).toHaveBeenCalledWith([1, 2, 3]);
+    });
+
+    it('returns 400 when noteIds is missing', async () => {
+      const res = await request(app).delete('/api/cards').send({});
+
+      expect(res.status).toBe(400);
+      expect(res.type).toMatch(/problem\+json/);
+    });
+  });
+
+  describe('GET /api/cards/search', () => {
+    it('returns matching notes for a query', async () => {
+      const mockNotes = [
+        {
+          noteId: 1,
+          fields: {
+            Front: { value: 'Q', order: 0 },
+            Back: { value: 'A', order: 1 },
+          },
+          tags: [],
+        },
+      ];
+      vi.mocked(ankiConnect.findNotes).mockResolvedValue([1]);
+      vi.mocked(ankiConnect.notesInfo).mockResolvedValue(mockNotes);
+
+      const res = await request(app)
+        .get('/api/cards/search')
+        .query({ q: 'deck:Default' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.data).toEqual(mockNotes);
+      expect(ankiConnect.findNotes).toHaveBeenCalledWith('deck:Default');
+    });
+
+    it('returns 400 when query param is missing', async () => {
+      const res = await request(app).get('/api/cards/search');
+
+      expect(res.status).toBe(400);
+      expect(res.type).toMatch(/problem\+json/);
+    });
+  });
+});

--- a/packages/backend/src/__tests__/decks.test.ts
+++ b/packages/backend/src/__tests__/decks.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import request from 'supertest';
+import { createApp } from '../app';
+import { ankiConnect } from '../services/ankiConnect';
+
+vi.mock('../services/ankiConnect', () => ({
+  ankiConnect: {
+    ping: vi.fn(),
+    getDeckNames: vi.fn(),
+    createDeck: vi.fn(),
+    deleteDeck: vi.fn(),
+    addNote: vi.fn(),
+    updateNoteFields: vi.fn(),
+    deleteNotes: vi.fn(),
+    findNotes: vi.fn(),
+    notesInfo: vi.fn(),
+    modelNames: vi.fn(),
+    ensureDeckExists: vi.fn(),
+  },
+}));
+
+const app = createApp();
+
+describe('Decks API', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('GET /api/decks', () => {
+    it('returns all deck names', async () => {
+      vi.mocked(ankiConnect.getDeckNames).mockResolvedValue([
+        'Default',
+        'Spanish',
+        'Programming',
+      ]);
+
+      const res = await request(app).get('/api/decks');
+
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.data).toEqual(['Default', 'Spanish', 'Programming']);
+    });
+
+    it('propagates AnkiConnect errors as 500', async () => {
+      vi.mocked(ankiConnect.getDeckNames).mockRejectedValue(
+        new Error('AnkiConnect unavailable')
+      );
+
+      const res = await request(app).get('/api/decks');
+
+      expect(res.status).toBe(500);
+      expect(res.type).toMatch(/problem\+json/);
+    });
+  });
+
+  describe('POST /api/decks', () => {
+    it('creates a deck and returns 201 with the new id', async () => {
+      vi.mocked(ankiConnect.getDeckNames).mockResolvedValue(['Default']); // assertDeckNotExists check
+      vi.mocked(ankiConnect.createDeck).mockResolvedValue(42);
+
+      const res = await request(app)
+        .post('/api/decks')
+        .send({ name: 'NewDeck' });
+
+      expect(res.status).toBe(201);
+      expect(res.body.success).toBe(true);
+      expect(res.body.data.id).toBe(42);
+      expect(ankiConnect.createDeck).toHaveBeenCalledWith('NewDeck');
+    });
+
+    it('returns 400 when name is missing', async () => {
+      const res = await request(app).post('/api/decks').send({});
+
+      expect(res.status).toBe(400);
+      expect(res.type).toMatch(/problem\+json/);
+      expect(res.body.type).toBe('/problems/validation-error');
+    });
+
+    it('returns 400 when deck already exists', async () => {
+      vi.mocked(ankiConnect.getDeckNames).mockResolvedValue([
+        'Default',
+        'ExistingDeck',
+      ]);
+
+      const res = await request(app)
+        .post('/api/decks')
+        .send({ name: 'ExistingDeck' });
+
+      expect(res.status).toBe(400);
+      expect(res.type).toMatch(/problem\+json/);
+    });
+  });
+
+  describe('DELETE /api/decks/:name', () => {
+    it('deletes a deck and returns 200', async () => {
+      vi.mocked(ankiConnect.getDeckNames).mockResolvedValue([
+        'Default',
+        'ToDelete',
+      ]);
+      vi.mocked(ankiConnect.deleteDeck).mockResolvedValue(undefined);
+
+      const res = await request(app)
+        .delete('/api/decks/ToDelete')
+        .send({ deleteCards: true });
+
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(ankiConnect.deleteDeck).toHaveBeenCalledWith('ToDelete', true);
+    });
+
+    it('returns 400 when deck does not exist', async () => {
+      vi.mocked(ankiConnect.getDeckNames).mockResolvedValue(['Default']);
+
+      const res = await request(app)
+        .delete('/api/decks/NonExistent')
+        .send({ deleteCards: false });
+
+      expect(res.status).toBe(400);
+      expect(res.type).toMatch(/problem\+json/);
+      expect(ankiConnect.deleteDeck).not.toHaveBeenCalled();
+    });
+
+    it('defaults deleteCards to false when not provided', async () => {
+      vi.mocked(ankiConnect.getDeckNames).mockResolvedValue([
+        'Default',
+        'ToDrop',
+      ]);
+      vi.mocked(ankiConnect.deleteDeck).mockResolvedValue(undefined);
+
+      await request(app).delete('/api/decks/ToDrop').send({});
+
+      expect(ankiConnect.deleteDeck).toHaveBeenCalledWith('ToDrop', false);
+    });
+  });
+});

--- a/packages/backend/src/__tests__/health.test.ts
+++ b/packages/backend/src/__tests__/health.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import request from 'supertest';
+import { createApp } from '../app';
+import { ankiConnect } from '../services/ankiConnect';
+
+vi.mock('../services/ankiConnect', () => ({
+  ankiConnect: {
+    ping: vi.fn(),
+    getDeckNames: vi.fn(),
+    createDeck: vi.fn(),
+    deleteDeck: vi.fn(),
+    addNote: vi.fn(),
+    updateNoteFields: vi.fn(),
+    deleteNotes: vi.fn(),
+    findNotes: vi.fn(),
+    notesInfo: vi.fn(),
+    modelNames: vi.fn(),
+    ensureDeckExists: vi.fn(),
+  },
+}));
+
+const app = createApp();
+
+describe('GET /health', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns 200 with healthy status when AnkiConnect is reachable', async () => {
+    vi.mocked(ankiConnect.ping).mockResolvedValue(true);
+
+    const res = await request(app).get('/health');
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.status).toBe('healthy');
+    expect(res.body.data.ankiConnect.connected).toBe(true);
+  });
+
+  it('returns 503 problem+json when AnkiConnect is unreachable', async () => {
+    vi.mocked(ankiConnect.ping).mockResolvedValue(false);
+
+    const res = await request(app).get('/health');
+
+    expect(res.status).toBe(503);
+    expect(res.type).toMatch(/problem\+json/);
+    expect(res.body.status).toBe(503);
+    expect(res.body.type).toBe('/problems/anki-connect-unavailable');
+  });
+});

--- a/packages/backend/src/routes/decks.ts
+++ b/packages/backend/src/routes/decks.ts
@@ -55,7 +55,6 @@ router.post(
 
 // Delete deck
 const DeleteDeckSchema = z.object({
-  name: z.string().min(1),
   deleteCards: z.boolean().default(false),
 });
 


### PR DESCRIPTION
## Summary

- Add `supertest` to backend devDependencies for HTTP route testing
- Add `health.test.ts` — 2 tests: 200 healthy / 503 problem+json when AnkiConnect is down
- Add `decks.test.ts` — 9 tests: GET list, POST create (happy + validation + conflict), DELETE (success + not-found + default body)
- Add `cards.test.ts` — 11 tests: POST create (happy + default model + missing deck/model + validation), PUT update, DELETE bulk, GET search
- **Bug fix:** `DeleteDeckSchema` in `routes/decks.ts` incorrectly required `name` in the request body even though the deck name is already in the route param `/:name` — this caused every DELETE without a `name` body field to return 400

All 24 backend tests passing (3 pre-existing + 21 new).

## Test plan
- [ ] `npm run test -w packages/backend` — 24 tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)