### PR TITLE
#56 Add ankiniki sync command

### DIFF
--- a/apps/cli/src/__tests__/sync.test.ts
+++ b/apps/cli/src/__tests__/sync.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createSyncCommand } from '../commands/sync';
+
+const mockClient = {
+  ping: vi.fn().mockResolvedValue(true),
+  sync: vi.fn().mockResolvedValue(undefined),
+};
+
+vi.mock('../anki-client', () => ({
+  AnkiClient: class {
+    constructor() {
+      return mockClient;
+    }
+  },
+}));
+
+vi.mock('ora', () => ({
+  default: vi.fn(() => {
+    return {
+      start: vi.fn().mockReturnThis(),
+      succeed: vi.fn().mockReturnThis(),
+      fail: vi.fn().mockReturnThis(),
+    };
+  }),
+}));
+
+vi.spyOn(console, 'log').mockImplementation(() => {});
+vi.spyOn(console, 'error').mockImplementation(() => {});
+
+describe('sync command', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockClient.ping.mockResolvedValue(true);
+    mockClient.sync.mockResolvedValue(undefined);
+  });
+
+  it('pings AnkiConnect then calls sync', async () => {
+    const cmd = createSyncCommand();
+    await cmd.parseAsync([], { from: 'user' });
+
+    expect(mockClient.ping).toHaveBeenCalled();
+    expect(mockClient.sync).toHaveBeenCalled();
+  });
+
+  it('exits when AnkiConnect is not reachable', async () => {
+    mockClient.ping.mockResolvedValueOnce(false);
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit: 1');
+    });
+
+    const cmd = createSyncCommand();
+    await expect(cmd.parseAsync([], { from: 'user' })).rejects.toThrow(
+      'process.exit: 1'
+    );
+
+    expect(mockClient.sync).not.toHaveBeenCalled();
+    exitSpy.mockRestore();
+  });
+
+  it('exits when sync throws', async () => {
+    mockClient.sync.mockRejectedValueOnce(new Error('AnkiWeb unreachable'));
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit: 1');
+    });
+
+    const cmd = createSyncCommand();
+    await expect(cmd.parseAsync([], { from: 'user' })).rejects.toThrow(
+      'process.exit: 1'
+    );
+
+    exitSpy.mockRestore();
+  });
+});

--- a/apps/cli/src/commands/sync.ts
+++ b/apps/cli/src/commands/sync.ts
@@ -1,0 +1,35 @@
+/**
+ * Sync command - Trigger AnkiWeb sync from the terminal
+ */
+
+import { Command } from 'commander';
+import chalk from 'chalk';
+import ora from 'ora';
+import { ANKI_MESSAGES } from '@ankiniki/shared';
+import { AnkiClient } from '../anki-client';
+
+export function createSyncCommand(): Command {
+  const command = new Command('sync');
+
+  command.description('Trigger AnkiWeb sync').action(async () => {
+    const client = new AnkiClient();
+
+    const connectSpinner = ora(ANKI_MESSAGES.CONNECTING).start();
+    if (!(await client.ping())) {
+      connectSpinner.fail(ANKI_MESSAGES.CANNOT_CONNECT);
+      process.exit(1);
+    }
+    connectSpinner.succeed(ANKI_MESSAGES.CONNECTED);
+
+    const syncSpinner = ora('Syncing with AnkiWeb…').start();
+    try {
+      await client.sync();
+      syncSpinner.succeed(chalk.green('Sync complete'));
+    } catch (error: any) {
+      syncSpinner.fail(chalk.red(`Sync failed: ${error.message}`));
+      process.exit(1);
+    }
+  });
+
+  return command;
+}

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -13,6 +13,7 @@ import { createExportCommand } from './commands/export';
 import { createBundleCommand } from './commands/bundle';
 import { createGenerateCommand } from './commands/generate';
 import { createStatusCommand } from './commands/status';
+import { createSyncCommand } from './commands/sync';
 import { APP_CONFIG } from '@ankiniki/shared';
 
 const program = new Command();
@@ -34,6 +35,7 @@ program.addCommand(createExportCommand());
 program.addCommand(createBundleCommand());
 program.addCommand(createGenerateCommand());
 program.addCommand(createStatusCommand());
+program.addCommand(createSyncCommand());
 
 // Global error handling
 process.on('unhandledRejection', error => {


### PR DESCRIPTION
Closes #56

## Summary

- New `ankiniki sync` command that triggers AnkiWeb sync via AnkiConnect
- Pings AnkiConnect first, exits cleanly if not reachable
- Spinner during sync (can take a few seconds)
- Exits with error if sync fails
- 3 tests: happy path, unreachable AnkiConnect, sync failure

## Usage

```
$ ankiniki sync
✓ Connected to Anki
✓ Sync complete
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)