### PR TITLE
#59 Add --stdin flag to generate command

### DIFF
--- a/apps/cli/src/__tests__/generate-stdin.test.ts
+++ b/apps/cli/src/__tests__/generate-stdin.test.ts
@@ -1,0 +1,239 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { EventEmitter } from 'events';
+import { createGenerateCommand } from '../commands/generate';
+
+// ── Mocks ──────────────────────────────────────────────────────────────────
+
+const mockAnkiClient = {
+  ping: vi.fn().mockResolvedValue(true),
+  getDeckNames: vi.fn().mockResolvedValue(['Default']),
+  createDeck: vi.fn().mockResolvedValue(1),
+  addNote: vi.fn().mockResolvedValue(12345),
+};
+
+vi.mock('../anki-client', () => ({
+  AnkiClient: class {
+    constructor() {
+      return mockAnkiClient;
+    }
+  },
+}));
+
+vi.mock('../backend-manager', () => ({
+  BackendManager: {
+    ensure: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+vi.mock('../config', () => ({
+  loadConfig: vi.fn().mockReturnValue({
+    defaultDeck: 'Default',
+    serverUrl: 'http://localhost:3001',
+  }),
+}));
+
+vi.mock('ora', () => ({
+  default: vi.fn(() => ({
+    start: vi.fn().mockReturnThis(),
+    succeed: vi.fn().mockReturnThis(),
+    fail: vi.fn().mockReturnThis(),
+    stop: vi.fn().mockReturnThis(),
+  })),
+}));
+
+vi.mock('inquirer', () => ({
+  default: {
+    prompt: vi.fn().mockResolvedValue({ selected: [0] }),
+  },
+}));
+
+vi.mock('axios', () => ({
+  default: {
+    post: vi.fn().mockResolvedValue({
+      data: {
+        success: true,
+        data: {
+          success: true,
+          cards: [
+            {
+              front: 'What is TypeScript?',
+              back: 'A typed superset of JavaScript',
+              tags: ['typescript'],
+              difficulty: 'beginner',
+              confidence_score: 0.9,
+            },
+          ],
+        },
+      },
+    }),
+    isAxiosError: vi.fn().mockReturnValue(false),
+  },
+}));
+
+const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function makeStdin(text: string): EventEmitter & { setEncoding: () => void } {
+  const emitter = new EventEmitter() as EventEmitter & {
+    setEncoding: () => void;
+  };
+  emitter.setEncoding = vi.fn() as unknown as () => void;
+  // Emit asynchronously so the listener is registered first
+  setImmediate(() => {
+    emitter.emit('data', text);
+    emitter.emit('end');
+  });
+  return emitter;
+}
+
+async function run(args: string[] = []) {
+  const cmd = createGenerateCommand();
+  await cmd.parseAsync(args, { from: 'user' });
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+describe('generate --stdin', () => {
+  let originalStdin: NodeJS.ReadStream;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAnkiClient.ping.mockResolvedValue(true);
+    mockAnkiClient.getDeckNames.mockResolvedValue(['Default']);
+    mockAnkiClient.addNote.mockResolvedValue(12345);
+    consoleSpy.mockImplementation(() => {});
+    consoleErrorSpy.mockImplementation(() => {});
+    originalStdin = process.stdin;
+  });
+
+  afterEach(() => {
+    Object.defineProperty(process, 'stdin', {
+      value: originalStdin,
+      writable: true,
+    });
+  });
+
+  function setStdin(text: string) {
+    Object.defineProperty(process, 'stdin', {
+      value: makeStdin(text),
+      writable: true,
+    });
+  }
+
+  it('reads content from stdin and generates cards', async () => {
+    setStdin('# TypeScript Guide\n\nTypeScript is a typed language.');
+
+    await run(['--stdin', '--yes']);
+
+    const { default: axios } = await import('axios');
+    expect(axios.post).toHaveBeenCalledWith(
+      expect.stringContaining('/api/ml/generate/cards'),
+      expect.objectContaining({
+        content: expect.stringContaining('TypeScript'),
+      }),
+      expect.any(Object)
+    );
+  });
+
+  it('shows <stdin> as the source label', async () => {
+    setStdin('# Hello\n\nSome content');
+
+    await run(['--stdin', '--yes']);
+
+    const output = consoleSpy.mock.calls.map(c => String(c[0])).join('\n');
+    expect(output).toContain('<stdin>');
+  });
+
+  it('auto-detects markdown from content starting with #', async () => {
+    setStdin('# Markdown heading\n\nSome content here.');
+
+    await run(['--stdin', '--yes']);
+
+    const { default: axios } = await import('axios');
+    expect(axios.post).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ content_type: 'markdown' }),
+      expect.any(Object)
+    );
+  });
+
+  it('auto-detects code from content with function keyword', async () => {
+    setStdin('function hello() { return "world"; }');
+
+    await run(['--stdin', '--yes']);
+
+    const { default: axios } = await import('axios');
+    expect(axios.post).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ content_type: 'code' }),
+      expect.any(Object)
+    );
+  });
+
+  it('falls back to text when no code or markdown markers', async () => {
+    setStdin('This is plain prose about something interesting.');
+
+    await run(['--stdin', '--yes']);
+
+    const { default: axios } = await import('axios');
+    expect(axios.post).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ content_type: 'text' }),
+      expect.any(Object)
+    );
+  });
+
+  it('--content-type overrides auto-detection', async () => {
+    setStdin('function foo() {}');
+
+    await run(['--stdin', '--content-type', 'markdown', '--yes']);
+
+    const { default: axios } = await import('axios');
+    expect(axios.post).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ content_type: 'markdown' }),
+      expect.any(Object)
+    );
+  });
+
+  it('exits when neither file nor --stdin is provided', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit: 1');
+    });
+
+    await expect(run([])).rejects.toThrow('process.exit: 1');
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('--stdin')
+    );
+    exitSpy.mockRestore();
+  });
+
+  it('exits when both file and --stdin are provided', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit: 1');
+    });
+
+    await expect(run(['somefile.md', '--stdin'])).rejects.toThrow(
+      'process.exit: 1'
+    );
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Cannot use both')
+    );
+    exitSpy.mockRestore();
+  });
+
+  it('exits when stdin content is empty', async () => {
+    setStdin('   \n  ');
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit: 1');
+    });
+
+    await expect(run(['--stdin'])).rejects.toThrow('process.exit: 1');
+
+    exitSpy.mockRestore();
+  });
+});

--- a/apps/cli/src/commands/generate.ts
+++ b/apps/cli/src/commands/generate.ts
@@ -25,6 +25,7 @@ interface GenerateOptions {
   lang?: string;
   tags?: string;
   yes?: boolean;
+  stdin?: boolean;
 }
 
 interface GeneratedCard {
@@ -66,6 +67,33 @@ function detectContentType(filePath: string): ContentType {
   return 'text';
 }
 
+function detectContentTypeFromContent(content: string): ContentType {
+  const trimmed = content.trimStart();
+  if (trimmed.startsWith('#')) {
+    return 'markdown';
+  }
+  if (
+    /\bfunction\b|\bdef\b|\bclass\b|\bconst\b|\blet\b|\bvar\b|\bimport\b/.test(
+      content
+    )
+  ) {
+    return 'code';
+  }
+  return 'text';
+}
+
+function readStdin(): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let data = '';
+    process.stdin.setEncoding('utf8');
+    process.stdin.on('data', chunk => {
+      data += chunk;
+    });
+    process.stdin.on('end', () => resolve(data));
+    process.stdin.on('error', reject);
+  });
+}
+
 function clip(str: string, max: number): string {
   return str.length > max ? `${str.slice(0, max)}…` : str;
 }
@@ -75,7 +103,8 @@ export function createGenerateCommand(): Command {
 
   command
     .description('Generate flashcards from a file using AI')
-    .argument('<file>', 'File to generate cards from')
+    .argument('[file]', 'File to generate cards from')
+    .option('--stdin', 'Read content from stdin instead of a file')
     .option(
       '-d, --deck <deck>',
       'Deck to add cards to (uses config default if omitted)'
@@ -93,29 +122,54 @@ export function createGenerateCommand(): Command {
     .option('--lang <language>', 'Programming language hint (for code files)')
     .option('--tags <tags>', 'Additional tags to apply (comma-separated)')
     .option('-y, --yes', 'Add all generated cards without confirmation prompt')
-    .action(async (file: string, options: GenerateOptions) => {
+    .action(async (file: string | undefined, options: GenerateOptions) => {
       const config = loadConfig();
       const deckName = options.deck || config.defaultDeck;
       const baseUrl = config.serverUrl;
       let cleanup: (() => void) | undefined;
 
       try {
-        // ── 1. Validate file ──────────────────────────────────────────────
-        const filePath = path.resolve(file);
-        if (!fs.existsSync(filePath)) {
-          console.error(chalk.red(`File not found: ${filePath}`));
+        // ── 1. Validate input source ──────────────────────────────────────
+        if (!file && !options.stdin) {
+          console.error(
+            chalk.red('Provide a file path or use --stdin to pipe content.')
+          );
+          process.exit(1);
+        }
+        if (file && options.stdin) {
+          console.error(
+            chalk.red('Cannot use both a file argument and --stdin.')
+          );
           process.exit(1);
         }
 
-        const content = fs.readFileSync(filePath, 'utf8');
+        let content: string;
+        let displaySource: string;
+        let contentType: ContentType;
+
+        if (options.stdin) {
+          content = await readStdin();
+          displaySource = '<stdin>';
+          contentType =
+            (options.contentType as ContentType | undefined) ??
+            detectContentTypeFromContent(content);
+        } else {
+          const filePath = path.resolve(file!);
+          if (!fs.existsSync(filePath)) {
+            console.error(chalk.red(`File not found: ${filePath}`));
+            process.exit(1);
+          }
+          content = fs.readFileSync(filePath, 'utf8');
+          displaySource = filePath;
+          contentType =
+            (options.contentType as ContentType | undefined) ??
+            detectContentType(filePath);
+        }
+
         if (!content.trim()) {
-          console.error(chalk.red('File is empty.'));
+          console.error(chalk.red('Input is empty.'));
           process.exit(1);
         }
-
-        const contentType: ContentType =
-          (options.contentType as ContentType | undefined) ??
-          detectContentType(filePath);
 
         const maxCards = Math.min(
           20,
@@ -128,7 +182,9 @@ export function createGenerateCommand(): Command {
               .filter(Boolean)
           : [];
 
-        console.log(chalk.bold('\n📄 File:         ') + chalk.cyan(filePath));
+        console.log(
+          chalk.bold('\n📄 File:         ') + chalk.cyan(displaySource)
+        );
         console.log(chalk.bold('   Content type: ') + chalk.cyan(contentType));
         console.log(chalk.bold('   Deck:         ') + chalk.cyan(deckName));
         console.log(


### PR DESCRIPTION
## Summary

- Makes `<file>` argument optional — now `[file]`
- Adds `--stdin` flag to read content from stdin instead of a file
- Auto-detects content type from heuristics when no file extension is available: starts with `#` → markdown, contains `function`/`class`/etc → code, else text
- `--content-type` still overrides auto-detection
- Validates that exactly one of file or `--stdin` is provided

## Usage

```bash
cat README.md | ankiniki generate --stdin
git diff HEAD~1 | ankiniki generate --stdin --content-type code --deck "Code Review"
echo "# Notes\n\nKey concept here" | ankiniki generate --stdin --yes
```

## Test plan

- [x] `reads content from stdin and generates cards`
- [x] `shows <stdin> as the source label`
- [x] `auto-detects markdown from content starting with #`
- [x] `auto-detects code from content with function keyword`
- [x] `falls back to text when no code or markdown markers`
- [x] `--content-type overrides auto-detection`
- [x] `exits when neither file nor --stdin is provided`
- [x] `exits when both file and --stdin are provided`
- [x] `exits when stdin content is empty`

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)