### PR TITLE
#60 Add ankiniki tag command

### DIFF
--- a/apps/cli/src/__tests__/tag.test.ts
+++ b/apps/cli/src/__tests__/tag.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createTagCommand } from '../commands/tag';
+
+// ── Client mock ────────────────────────────────────────────────────────────
+
+const mockClient = {
+  ping: vi.fn().mockResolvedValue(true),
+  findNotes: vi.fn().mockResolvedValue([101, 102, 103]),
+  addTags: vi.fn().mockResolvedValue(undefined),
+  removeTags: vi.fn().mockResolvedValue(undefined),
+};
+
+vi.mock('../anki-client', () => ({
+  AnkiClient: class {
+    constructor() {
+      return mockClient;
+    }
+  },
+}));
+
+vi.mock('ora', () => ({
+  default: vi.fn(() => ({
+    start: vi.fn().mockReturnThis(),
+    succeed: vi.fn().mockReturnThis(),
+    fail: vi.fn().mockReturnThis(),
+    stop: vi.fn().mockReturnThis(),
+  })),
+}));
+
+// inquirer is dynamically imported inside the action; mock via the module registry
+const mockInquirerPrompt = vi.fn().mockResolvedValue({ ok: true });
+vi.mock('inquirer', () => ({
+  default: {
+    prompt: (...args: unknown[]) => mockInquirerPrompt(...args),
+  },
+}));
+
+const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+async function run(args: string[]) {
+  const cmd = createTagCommand();
+  await cmd.parseAsync(args, { from: 'user' });
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+describe('tag command', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockClient.ping.mockResolvedValue(true);
+    mockClient.findNotes.mockResolvedValue([101, 102, 103]);
+    mockClient.addTags.mockResolvedValue(undefined);
+    mockClient.removeTags.mockResolvedValue(undefined);
+    mockInquirerPrompt.mockResolvedValue({ ok: true });
+    consoleSpy.mockImplementation(() => {});
+    consoleErrorSpy.mockImplementation(() => {});
+  });
+
+  it('adds tags to all matched notes', async () => {
+    await run(['deck:Japanese', '--add', 'n+1,review', '--yes']);
+
+    expect(mockClient.addTags).toHaveBeenCalledWith(
+      [101, 102, 103],
+      'n+1 review'
+    );
+    expect(mockClient.removeTags).not.toHaveBeenCalled();
+  });
+
+  it('removes tags from all matched notes', async () => {
+    await run(['deck:Japanese', '--remove', 'old-tag', '--yes']);
+
+    expect(mockClient.removeTags).toHaveBeenCalledWith(
+      [101, 102, 103],
+      'old-tag'
+    );
+    expect(mockClient.addTags).not.toHaveBeenCalled();
+  });
+
+  it('adds and removes in the same call', async () => {
+    await run([
+      'tag:js',
+      '--add',
+      'typescript',
+      '--remove',
+      'javascript',
+      '--yes',
+    ]);
+
+    expect(mockClient.addTags).toHaveBeenCalledWith(
+      [101, 102, 103],
+      'typescript'
+    );
+    expect(mockClient.removeTags).toHaveBeenCalledWith(
+      [101, 102, 103],
+      'javascript'
+    );
+  });
+
+  it('scopes search to deck when --deck is set', async () => {
+    await run(['type:note', '--add', 'x', '--deck', 'Spanish', '--yes']);
+
+    expect(mockClient.findNotes).toHaveBeenCalledWith(
+      'deck:"Spanish" type:note'
+    );
+  });
+
+  it('shows a confirmation prompt without --yes', async () => {
+    mockInquirerPrompt.mockResolvedValueOnce({ ok: true });
+
+    await run(['deck:Japanese', '--add', 'n+1']);
+
+    expect(mockInquirerPrompt).toHaveBeenCalled();
+    expect(mockClient.addTags).toHaveBeenCalled();
+  });
+
+  it('aborts when user declines confirmation', async () => {
+    mockInquirerPrompt.mockResolvedValueOnce({ ok: false });
+
+    await run(['deck:Japanese', '--add', 'n+1']);
+
+    expect(mockClient.addTags).not.toHaveBeenCalled();
+    const output = consoleSpy.mock.calls.map(c => String(c[0])).join('\n');
+    expect(output).toContain('Aborted');
+  });
+
+  it('exits when neither --add nor --remove is provided', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit: 1');
+    });
+
+    await expect(run(['deck:Japanese'])).rejects.toThrow('process.exit: 1');
+
+    expect(mockClient.findNotes).not.toHaveBeenCalled();
+    exitSpy.mockRestore();
+  });
+
+  it('exits when no notes are found', async () => {
+    mockClient.findNotes.mockResolvedValue([]);
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit: 1');
+    });
+
+    await expect(run(['deck:Empty', '--add', 'x', '--yes'])).rejects.toThrow(
+      'process.exit: 1'
+    );
+
+    expect(mockClient.addTags).not.toHaveBeenCalled();
+    exitSpy.mockRestore();
+  });
+
+  it('exits when AnkiConnect is unreachable', async () => {
+    mockClient.ping.mockResolvedValue(false);
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit: 1');
+    });
+
+    await expect(run(['deck:Japanese', '--add', 'x'])).rejects.toThrow(
+      'process.exit: 1'
+    );
+
+    expect(mockClient.findNotes).not.toHaveBeenCalled();
+    exitSpy.mockRestore();
+  });
+});

--- a/apps/cli/src/commands/tag.ts
+++ b/apps/cli/src/commands/tag.ts
@@ -1,0 +1,139 @@
+/**
+ * Tag command - Bulk add/remove tags on notes matching a query
+ */
+
+import { Command } from 'commander';
+import chalk from 'chalk';
+import ora from 'ora';
+import { ANKI_MESSAGES } from '@ankiniki/shared';
+import { AnkiClient } from '../anki-client';
+
+function parseTags(raw: string): string[] {
+  return raw
+    .split(',')
+    .map(t => t.trim())
+    .filter(Boolean);
+}
+
+export function createTagCommand(): Command {
+  const command = new Command('tag');
+
+  command
+    .description('Bulk add or remove tags on notes matching a query')
+    .argument('<query>', 'AnkiConnect search query (e.g. "deck:Japanese")')
+    .option('--add <tags>', 'Comma-separated tags to add')
+    .option('--remove <tags>', 'Comma-separated tags to remove')
+    .option('-d, --deck <name>', 'Scope search to a specific deck')
+    .option('-y, --yes', 'Skip confirmation prompt')
+    .action(
+      async (
+        query: string,
+        options: {
+          add?: string;
+          remove?: string;
+          deck?: string;
+          yes?: boolean;
+        }
+      ) => {
+        if (!options.add && !options.remove) {
+          console.error(
+            chalk.red('Provide at least one of --add or --remove.')
+          );
+          process.exit(1);
+        }
+
+        const tagsToAdd = options.add ? parseTags(options.add) : [];
+        const tagsToRemove = options.remove ? parseTags(options.remove) : [];
+
+        const client = new AnkiClient();
+
+        const connSpinner = ora(ANKI_MESSAGES.CONNECTING).start();
+        if (!(await client.ping())) {
+          connSpinner.fail(ANKI_MESSAGES.CANNOT_CONNECT);
+          process.exit(1);
+        }
+        connSpinner.succeed(ANKI_MESSAGES.CONNECTED);
+
+        // ── 1. Search ─────────────────────────────────────────────────────
+        const fullQuery = options.deck
+          ? `deck:"${options.deck}" ${query}`
+          : query;
+
+        const searchSpinner = ora('Searching…').start();
+        let noteIds: number[];
+        try {
+          noteIds = await client.findNotes(fullQuery);
+        } catch (error: any) {
+          searchSpinner.fail(chalk.red(`Search failed: ${error.message}`));
+          process.exit(1);
+        }
+
+        if (noteIds.length === 0) {
+          searchSpinner.fail(chalk.yellow('No notes found for that query.'));
+          process.exit(1);
+        }
+
+        searchSpinner.succeed(
+          `Found ${chalk.white.bold(String(noteIds.length))} note${noteIds.length !== 1 ? 's' : ''}`
+        );
+
+        // ── 2. Preview ────────────────────────────────────────────────────
+        console.log();
+        if (tagsToAdd.length) {
+          console.log(
+            `  ${chalk.green('+')} Add:    ${tagsToAdd.map(t => chalk.green(t)).join('  ')}`
+          );
+        }
+        if (tagsToRemove.length) {
+          console.log(
+            `  ${chalk.red('-')} Remove: ${tagsToRemove.map(t => chalk.red(t)).join('  ')}`
+          );
+        }
+        console.log(
+          `  ${chalk.gray('Affects')} ${chalk.white.bold(String(noteIds.length))} note${noteIds.length !== 1 ? 's' : ''}`
+        );
+        console.log();
+
+        // ── 3. Confirm ────────────────────────────────────────────────────
+        if (!options.yes) {
+          const { default: inquirer } = await import('inquirer');
+          const { ok } = await inquirer.prompt<{ ok: boolean }>([
+            {
+              type: 'confirm',
+              name: 'ok',
+              message: 'Apply these tag changes?',
+              default: true,
+            },
+          ]);
+          if (!ok) {
+            console.log(chalk.yellow('Aborted.'));
+            return;
+          }
+        }
+
+        // ── 4. Apply ──────────────────────────────────────────────────────
+        const applySpinner = ora('Applying tag changes…').start();
+        try {
+          // AnkiConnect expects tags as a space-separated string
+          if (tagsToAdd.length) {
+            await client.addTags(noteIds, tagsToAdd.join(' '));
+          }
+          if (tagsToRemove.length) {
+            await client.removeTags(noteIds, tagsToRemove.join(' '));
+          }
+          applySpinner.succeed(
+            chalk.green(
+              `Updated tags on ${noteIds.length} note${noteIds.length !== 1 ? 's' : ''}`
+            )
+          );
+        } catch (error: any) {
+          applySpinner.fail(
+            chalk.red(`Failed to update tags: ${error.message}`)
+          );
+          process.exit(1);
+        }
+      }
+    );
+
+  return command;
+}

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -16,6 +16,7 @@ import { createGenerateCommand } from './commands/generate';
 import { createStatusCommand } from './commands/status';
 import { createSyncCommand } from './commands/sync';
 import { createStatsCommand } from './commands/stats';
+import { createTagCommand } from './commands/tag';
 import { APP_CONFIG } from '@ankiniki/shared';
 
 const program = new Command();
@@ -40,6 +41,7 @@ program.addCommand(createGenerateCommand());
 program.addCommand(createStatusCommand());
 program.addCommand(createSyncCommand());
 program.addCommand(createStatsCommand());
+program.addCommand(createTagCommand());
 
 // Global error handling
 process.on('unhandledRejection', error => {

--- a/packages/shared/src/anki-client.ts
+++ b/packages/shared/src/anki-client.ts
@@ -186,6 +186,14 @@ export class AnkiConnectClient {
     return this.request<void>('deleteNotes', { notes: noteIds });
   }
 
+  async addTags(noteIds: number[], tags: string): Promise<void> {
+    return this.request<void>('addTags', { notes: noteIds, tags });
+  }
+
+  async removeTags(noteIds: number[], tags: string): Promise<void> {
+    return this.request<void>('removeTags', { notes: noteIds, tags });
+  }
+
   async canAddNotes(notes: Record<string, unknown>[]): Promise<boolean[]> {
     return this.request<boolean[]>('canAddNotes', { notes });
   }


### PR DESCRIPTION
## Summary

- `ankiniki tag <query> --add <tags> --remove <tags>` bulk-updates tags on all matching notes
- At least one of `--add` or `--remove` is required
- Shows a preview of what will change and how many notes are affected, then confirms before applying
- `--yes` skips the confirmation prompt (useful in scripts)
- Tags are passed to AnkiConnect as a space-separated string (its expected format)
- Also adds `addTags` and `removeTags` methods to `AnkiConnectClient` in `@ankiniki/shared`

## Options

| Flag | Description |
|------|-------------|
| `--add <tags>` | Comma-separated tags to add |
| `--remove <tags>` | Comma-separated tags to remove |
| `-d, --deck <name>` | Scope search to a specific deck |
| `-y, --yes` | Skip confirmation prompt |

## Usage

```bash
ankiniki tag "deck:Japanese" --add "n+1,active"
ankiniki tag "tag:old-tag" --remove "old-tag" --add "new-tag" --yes
ankiniki tag "added:7" --add "this-week" --deck "Work" --yes
```

## Test plan

- [x] adds tags to all matched notes
- [x] removes tags from all matched notes
- [x] adds and removes in the same call
- [x] scopes search to deck when `--deck` is set
- [x] shows confirmation prompt without `--yes`
- [x] aborts when user declines confirmation
- [x] exits when neither `--add` nor `--remove` provided
- [x] exits when no notes found
- [x] exits when AnkiConnect unreachable

Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)