### PR TITLE
#61 Extend export command with CSV and JSON formats

### DIFF
--- a/apps/cli/src/__tests__/export.test.ts
+++ b/apps/cli/src/__tests__/export.test.ts
@@ -1,0 +1,263 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createExportCommand } from '../commands/export';
+
+// ── Fixtures ───────────────────────────────────────────────────────────────
+
+const NOTES = [
+  {
+    noteId: 101,
+    modelName: 'Basic',
+    tags: ['ts', 'beginner'],
+    fields: {
+      Front: { value: 'What is TypeScript?', order: 0 },
+      Back: { value: 'A typed superset of JavaScript', order: 1 },
+    },
+    cards: [1001],
+  },
+  {
+    noteId: 102,
+    modelName: 'Basic',
+    tags: [],
+    fields: {
+      Front: { value: 'What is a union type?', order: 0 },
+      Back: { value: 'A | B', order: 1 },
+    },
+    cards: [1002],
+  },
+];
+
+// ── fs mock ────────────────────────────────────────────────────────────────
+
+const mockExistsSync = vi.fn().mockReturnValue(true);
+const mockWriteFileSync = vi.fn();
+const mockStatSync = vi.fn().mockReturnValue({ size: 2048 });
+
+vi.mock('fs', () => {
+  const fsMock = {
+    existsSync: (...args: unknown[]) => mockExistsSync(...args),
+    writeFileSync: (...args: unknown[]) => mockWriteFileSync(...args),
+    statSync: (...args: unknown[]) => mockStatSync(...args),
+  };
+  return { default: fsMock, ...fsMock };
+});
+
+// ── path mock (keep dirname real) ──────────────────────────────────────────
+// path is not mocked — we let it run naturally
+
+// ── Client mock ────────────────────────────────────────────────────────────
+
+const mockClient = {
+  ping: vi.fn().mockResolvedValue(true),
+  getDeckNames: vi.fn().mockResolvedValue(['TypeScript', 'Japanese']),
+  exportPackage: vi.fn().mockResolvedValue(true),
+  findNotes: vi.fn().mockResolvedValue([101, 102]),
+  notesInfo: vi.fn().mockResolvedValue(NOTES),
+};
+
+vi.mock('../anki-client', () => ({
+  AnkiClient: class {
+    constructor() {
+      return mockClient;
+    }
+  },
+}));
+
+vi.mock('ora', () => ({
+  default: vi.fn(() => ({
+    start: vi.fn().mockReturnThis(),
+    succeed: vi.fn().mockReturnThis(),
+    fail: vi.fn().mockReturnThis(),
+    stop: vi.fn().mockReturnThis(),
+  })),
+}));
+
+const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+vi.spyOn(console, 'error').mockImplementation(() => {});
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+async function run(args: string[]) {
+  const cmd = createExportCommand();
+  await cmd.parseAsync(args, { from: 'user' });
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+describe('export command', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockClient.ping.mockResolvedValue(true);
+    mockClient.getDeckNames.mockResolvedValue(['TypeScript', 'Japanese']);
+    mockClient.exportPackage.mockResolvedValue(true);
+    mockClient.findNotes.mockResolvedValue([101, 102]);
+    mockClient.notesInfo.mockResolvedValue(NOTES);
+    mockExistsSync.mockReturnValue(true);
+    mockStatSync.mockReturnValue({ size: 2048 });
+    consoleSpy.mockImplementation(() => {});
+  });
+
+  // ── apkg ──────────────────────────────────────────────────────────────────
+
+  describe('--format apkg (default)', () => {
+    it('calls exportPackage with the deck and resolved path', async () => {
+      await run(['TypeScript', '/tmp/out.apkg']);
+
+      expect(mockClient.exportPackage).toHaveBeenCalledWith(
+        'TypeScript',
+        '/tmp/out.apkg',
+        false
+      );
+    });
+
+    it('passes includeSched when --include-sched is set', async () => {
+      await run(['TypeScript', '/tmp/out.apkg', '--include-sched']);
+
+      expect(mockClient.exportPackage).toHaveBeenCalledWith(
+        'TypeScript',
+        '/tmp/out.apkg',
+        true
+      );
+    });
+
+    it('does not call findNotes for apkg format', async () => {
+      await run(['TypeScript', '/tmp/out.apkg']);
+
+      expect(mockClient.findNotes).not.toHaveBeenCalled();
+    });
+
+    it('exits when deck is not found', async () => {
+      const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+        throw new Error('process.exit: 1');
+      });
+
+      await expect(run(['NonExistent', '/tmp/out.apkg'])).rejects.toThrow(
+        'process.exit: 1'
+      );
+
+      expect(mockClient.exportPackage).not.toHaveBeenCalled();
+      exitSpy.mockRestore();
+    });
+  });
+
+  // ── csv ───────────────────────────────────────────────────────────────────
+
+  describe('--format csv', () => {
+    it('queries deck notes and writes a CSV file', async () => {
+      await run(['TypeScript', '/tmp/out.csv', '--format', 'csv']);
+
+      expect(mockClient.findNotes).toHaveBeenCalledWith('deck:"TypeScript"');
+      expect(mockWriteFileSync).toHaveBeenCalledWith(
+        '/tmp/out.csv',
+        expect.stringContaining('noteId'),
+        'utf8'
+      );
+    });
+
+    it('CSV contains field values', async () => {
+      await run(['TypeScript', '/tmp/out.csv', '--format', 'csv']);
+
+      const csv: string = mockWriteFileSync.mock.calls[0][1] as string;
+      expect(csv).toContain('What is TypeScript?');
+      expect(csv).toContain('A typed superset of JavaScript');
+    });
+
+    it('CSV has a header row with field names', async () => {
+      await run(['TypeScript', '/tmp/out.csv', '--format', 'csv']);
+
+      const csv: string = mockWriteFileSync.mock.calls[0][1] as string;
+      const firstLine = csv.split('\n')[0];
+      expect(firstLine).toContain('noteId');
+      expect(firstLine).toContain('Front');
+      expect(firstLine).toContain('Back');
+      expect(firstLine).toContain('tags');
+    });
+
+    it('scopes query with --query flag', async () => {
+      await run([
+        'TypeScript',
+        '/tmp/out.csv',
+        '--format',
+        'csv',
+        '--query',
+        'tag:beginner',
+      ]);
+
+      expect(mockClient.findNotes).toHaveBeenCalledWith(
+        'deck:"TypeScript" tag:beginner'
+      );
+    });
+
+    it('does not call exportPackage for csv format', async () => {
+      await run(['TypeScript', '/tmp/out.csv', '--format', 'csv']);
+
+      expect(mockClient.exportPackage).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── json ──────────────────────────────────────────────────────────────────
+
+  describe('--format json', () => {
+    it('queries deck notes and writes a JSON file', async () => {
+      await run(['TypeScript', '/tmp/out.json', '--format', 'json']);
+
+      expect(mockClient.findNotes).toHaveBeenCalledWith('deck:"TypeScript"');
+      expect(mockWriteFileSync).toHaveBeenCalledWith(
+        '/tmp/out.json',
+        expect.stringContaining('"noteId"'),
+        'utf8'
+      );
+    });
+
+    it('JSON is valid and contains note data', async () => {
+      await run(['TypeScript', '/tmp/out.json', '--format', 'json']);
+
+      const raw: string = mockWriteFileSync.mock.calls[0][1] as string;
+      const parsed = JSON.parse(raw);
+      expect(Array.isArray(parsed)).toBe(true);
+      expect(parsed).toHaveLength(2);
+      expect(parsed[0]).toMatchObject({
+        noteId: 101,
+        modelName: 'Basic',
+        tags: ['ts', 'beginner'],
+        fields: {
+          Front: 'What is TypeScript?',
+          Back: 'A typed superset of JavaScript',
+        },
+      });
+    });
+
+    it('does not call exportPackage for json format', async () => {
+      await run(['TypeScript', '/tmp/out.json', '--format', 'json']);
+
+      expect(mockClient.exportPackage).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── shared error paths ────────────────────────────────────────────────────
+
+  it('exits on unknown format', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit: 1');
+    });
+
+    await expect(
+      run(['TypeScript', '/tmp/out.xyz', '--format', 'xlsx'])
+    ).rejects.toThrow('process.exit: 1');
+
+    exitSpy.mockRestore();
+  });
+
+  it('exits when AnkiConnect is unreachable', async () => {
+    mockClient.ping.mockResolvedValue(false);
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit: 1');
+    });
+
+    await expect(run(['TypeScript', '/tmp/out.apkg'])).rejects.toThrow(
+      'process.exit: 1'
+    );
+
+    expect(mockClient.getDeckNames).not.toHaveBeenCalled();
+    exitSpy.mockRestore();
+  });
+});

--- a/apps/cli/src/commands/export.ts
+++ b/apps/cli/src/commands/export.ts
@@ -1,5 +1,5 @@
 /**
- * Export command - Export a deck as an Anki package (.apkg)
+ * Export command - Export notes from Anki to .apkg, CSV, or JSON
  */
 
 import { Command } from 'commander';
@@ -7,92 +7,225 @@ import fs from 'fs';
 import path from 'path';
 import chalk from 'chalk';
 import ora from 'ora';
-import { ANKI_MESSAGES } from '@ankiniki/shared';
+import { ANKI_MESSAGES, type NoteInfo } from '@ankiniki/shared';
 import { AnkiClient } from '../anki-client';
+
+type Format = 'apkg' | 'csv' | 'json';
+
+const DEFAULT_FORMAT: Format = 'apkg';
+
+function csvEscape(value: string): string {
+  if (value.includes('"') || value.includes(',') || value.includes('\n')) {
+    return `"${value.replace(/"/g, '""')}"`;
+  }
+  return value;
+}
+
+function notesToCsv(notes: NoteInfo[]): string {
+  if (notes.length === 0) {
+    return '';
+  }
+
+  // Collect all unique field names (sorted by order from first note)
+  const firstNote = notes[0];
+  const fieldNames = Object.entries(firstNote.fields)
+    .sort(([, a], [, b]) => a.order - b.order)
+    .map(([name]) => name);
+
+  const header = ['noteId', ...fieldNames, 'tags', 'modelName']
+    .map(csvEscape)
+    .join(',');
+
+  const rows = notes.map(note => {
+    const fieldValues = fieldNames.map(name =>
+      csvEscape(note.fields[name]?.value ?? '')
+    );
+    return [
+      String(note.noteId),
+      ...fieldValues,
+      csvEscape(note.tags.join(' ')),
+      csvEscape(note.modelName),
+    ].join(',');
+  });
+
+  return `${[header, ...rows].join('\n')}\n`;
+}
+
+function notesToJson(notes: NoteInfo[]): string {
+  const records = notes.map(note => {
+    const fields: Record<string, string> = {};
+    for (const [name, { value }] of Object.entries(note.fields)) {
+      fields[name] = value;
+    }
+    return {
+      noteId: note.noteId,
+      modelName: note.modelName,
+      tags: note.tags,
+      fields,
+    };
+  });
+  return `${JSON.stringify(records, null, 2)}\n`;
+}
 
 export function createExportCommand(): Command {
   const command = new Command('export');
 
   command
-    .description('Export a deck as an Anki package (.apkg)')
+    .description('Export notes from Anki to .apkg, CSV, or JSON')
     .argument('<deck>', 'Deck name to export')
-    .argument(
-      '[output]',
-      'Output file path (default: <deck>.apkg in current dir)'
+    .argument('[output]', 'Output file path (default: <deck>.<format>)')
+    .option(
+      '-f, --format <fmt>',
+      'Output format: apkg | csv | json',
+      DEFAULT_FORMAT
     )
-    .option('--include-sched', 'Include scheduling and review history data')
+    .option(
+      '-q, --query <query>',
+      'Extra query to filter notes (csv/json only, e.g. "tag:js")'
+    )
+    .option(
+      '--include-sched',
+      'Include scheduling/review history data (apkg only)'
+    )
     .action(
       async (
         deck: string,
         output: string | undefined,
-        options: { includeSched?: boolean }
+        options: {
+          format: string;
+          query?: string;
+          includeSched?: boolean;
+        }
       ) => {
+        const format = options.format as Format;
+        if (!['apkg', 'csv', 'json'].includes(format)) {
+          console.error(
+            chalk.red(`Unknown format "${format}". Use apkg, csv, or json.`)
+          );
+          process.exit(1);
+        }
+
         const client = new AnkiClient();
 
-        try {
-          const spinner = ora(ANKI_MESSAGES.CONNECTING).start();
-          if (!(await client.ping())) {
-            spinner.fail(ANKI_MESSAGES.CANNOT_CONNECT);
-            process.exit(1);
-          }
-          spinner.succeed(ANKI_MESSAGES.CONNECTED);
+        const connSpinner = ora(ANKI_MESSAGES.CONNECTING).start();
+        if (!(await client.ping())) {
+          connSpinner.fail(ANKI_MESSAGES.CANNOT_CONNECT);
+          process.exit(1);
+        }
+        connSpinner.succeed(ANKI_MESSAGES.CONNECTED);
 
-          // Verify deck exists
-          const decks = await client.getDeckNames();
-          if (!decks.includes(deck)) {
-            console.error(chalk.red(`Deck "${deck}" not found`));
-            console.log(chalk.gray('Available decks:'));
-            decks.forEach(d => console.log(chalk.gray(`  - ${d}`)));
-            process.exit(1);
-          }
+        // Verify deck exists
+        const decks = await client.getDeckNames();
+        if (!decks.includes(deck)) {
+          console.error(chalk.red(`Deck "${deck}" not found`));
+          console.log(chalk.gray('Available decks:'));
+          decks.forEach(d => console.log(chalk.gray(`  - ${d}`)));
+          process.exit(1);
+        }
 
-          // Resolve output path
-          const safeName = deck.replace(/[^a-zA-Z0-9_\-. ]/g, '_');
-          const outputPath = output
-            ? path.resolve(output)
-            : path.resolve(process.cwd(), `${safeName}.apkg`);
+        // Resolve output path
+        const safeName = deck.replace(/[^a-zA-Z0-9_\-. ]/g, '_');
+        const outputPath = output
+          ? path.resolve(output)
+          : path.resolve(process.cwd(), `${safeName}.${format}`);
 
-          // Ensure parent directory exists
-          const outputDir = path.dirname(outputPath);
-          if (!fs.existsSync(outputDir)) {
-            console.error(
-              chalk.red(`Output directory does not exist: ${outputDir}`)
-            );
-            process.exit(1);
-          }
-
-          const exportSpinner = ora(`Exporting "${deck}"...`).start();
-          const ok = await client.exportPackage(
-            deck,
-            outputPath,
-            options.includeSched ?? false
+        const outputDir = path.dirname(outputPath);
+        if (!fs.existsSync(outputDir)) {
+          console.error(
+            chalk.red(`Output directory does not exist: ${outputDir}`)
           );
+          process.exit(1);
+        }
 
-          if (!ok) {
-            exportSpinner.fail('AnkiConnect failed to export the deck');
+        // ── .apkg export (via AnkiConnect) ─────────────────────────────────
+        if (format === 'apkg') {
+          const exportSpinner = ora(`Exporting "${deck}"…`).start();
+          try {
+            const ok = await client.exportPackage(
+              deck,
+              outputPath,
+              options.includeSched ?? false
+            );
+
+            if (!ok) {
+              exportSpinner.fail('AnkiConnect failed to export the deck');
+              process.exit(1);
+            }
+
+            if (!fs.existsSync(outputPath)) {
+              exportSpinner.fail('Export file was not created');
+              process.exit(1);
+            }
+
+            const size = fs.statSync(outputPath).size;
+            const sizeStr =
+              size >= 1024 * 1024
+                ? `${(size / (1024 * 1024)).toFixed(1)} MB`
+                : `${Math.round(size / 1024)} KB`;
+
+            exportSpinner.succeed(
+              `Exported "${deck}" → ${chalk.cyan(outputPath)} ${chalk.gray(`(${sizeStr})`)}`
+            );
+            if (options.includeSched) {
+              console.log(chalk.gray('  Scheduling data included'));
+            }
+          } catch (error: any) {
+            exportSpinner.fail(chalk.red(`Export failed: ${error.message}`));
             process.exit(1);
           }
+          return;
+        }
 
-          if (!fs.existsSync(outputPath)) {
-            exportSpinner.fail('Export file was not created');
-            process.exit(1);
-          }
+        // ── CSV / JSON export (via findNotes + notesInfo) ──────────────────
+        const baseQuery = `deck:"${deck}"`;
+        const fullQuery = options.query
+          ? `${baseQuery} ${options.query}`
+          : baseQuery;
+
+        const searchSpinner = ora('Fetching notes…').start();
+        let noteIds: number[];
+        try {
+          noteIds = await client.findNotes(fullQuery);
+        } catch (error: any) {
+          searchSpinner.fail(chalk.red(`Search failed: ${error.message}`));
+          process.exit(1);
+        }
+
+        if (noteIds.length === 0) {
+          searchSpinner.fail(chalk.yellow('No notes found in that deck.'));
+          process.exit(1);
+        }
+
+        let notes: NoteInfo[];
+        try {
+          notes = await client.notesInfo(noteIds);
+          searchSpinner.succeed(
+            `Fetched ${chalk.white.bold(String(notes.length))} note${notes.length !== 1 ? 's' : ''}`
+          );
+        } catch (error: any) {
+          searchSpinner.fail(
+            chalk.red(`Failed to fetch note details: ${error.message}`)
+          );
+          process.exit(1);
+        }
+
+        const writeSpinner = ora(`Writing ${format.toUpperCase()}…`).start();
+        try {
+          const content =
+            format === 'csv' ? notesToCsv(notes) : notesToJson(notes);
+          fs.writeFileSync(outputPath, content, 'utf8');
 
           const size = fs.statSync(outputPath).size;
           const sizeStr =
-            size >= 1024 * 1024
-              ? `${(size / (1024 * 1024)).toFixed(1)} MB`
-              : `${Math.round(size / 1024)} KB`;
+            size >= 1024 ? `${Math.round(size / 1024)} KB` : `${size} B`;
 
-          exportSpinner.succeed(
-            `Exported "${deck}" → ${chalk.cyan(outputPath)} ${chalk.gray(`(${sizeStr})`)}`
+          writeSpinner.succeed(
+            `Exported ${notes.length} note${notes.length !== 1 ? 's' : ''} → ${chalk.cyan(outputPath)} ${chalk.gray(`(${sizeStr})`)}`
           );
-
-          if (options.includeSched) {
-            console.log(chalk.gray('  Scheduling data included'));
-          }
         } catch (error: any) {
-          console.error(chalk.red(`Error: ${error.message}`));
+          writeSpinner.fail(
+            chalk.red(`Failed to write file: ${error.message}`)
+          );
           process.exit(1);
         }
       }


### PR DESCRIPTION
## Summary

Extends the existing `export` command with a `--format` option instead of creating a new command.

- `--format apkg` (default) — unchanged behaviour, delegates to AnkiConnect `exportPackage`
- `--format csv` — fetches notes via `findNotes` + `notesInfo`, serialises to RFC-4180 CSV with proper quoting
- `--format json` — same fetch path, serialises to a JSON array with `noteId`, `modelName`, `tags`, `fields`
- `--query <query>` — extra filter applied when using csv/json (e.g. `tag:beginner`)
- Output file defaults to `<deck>.<format>` in cwd when no path is given

## Usage

```bash
ankiniki export TypeScript                          # → TypeScript.apkg (unchanged)
ankiniki export TypeScript notes.csv --format csv
ankiniki export TypeScript --format json --query "tag:hard"
ankiniki export Japanese deck.apkg --include-sched
```

## Test plan

- [x] `exportPackage` called with correct args for apkg
- [x] `--include-sched` forwarded correctly
- [x] `findNotes` not called for apkg format
- [x] exits when deck not found
- [x] CSV: `findNotes` called with deck scope
- [x] CSV: field values present in output
- [x] CSV: header row contains `noteId`, field names, `tags`
- [x] CSV: `--query` appended to search
- [x] CSV: `exportPackage` not called
- [x] JSON: `findNotes` called, file written
- [x] JSON: output is valid JSON with correct shape
- [x] JSON: `exportPackage` not called
- [x] exits on unknown format
- [x] exits when AnkiConnect unreachable

Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)