### PR TITLE
#68 Clean sweep: reorganise CLI API under note/deck subcommands

### DIFF
--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -16,68 +16,93 @@ npm link
 
 ## Usage
 
-### Basic Commands
+Commands are grouped into two main areas — **`note`** for card operations and **`deck`** for deck management — plus a set of standalone utility commands.
 
-```bash
-# Show help
-ankiniki --help
-
-# Add a new card
-ankiniki add "What is React?" "A JavaScript library for building user interfaces"
-
-# Add card to specific deck
-ankiniki add "JavaScript Basics" "What is a closure?" "A function that has access to outer function variables"
-
-# Interactive card creation
-ankiniki add --interactive
-
-# List all decks
-ankiniki list
-
-# List cards in a deck
-ankiniki list --cards "JavaScript Basics"
-
-# Study cards
-ankiniki study
-
-# Study specific deck
-ankiniki study "React Concepts"
-
-# Configuration
-ankiniki config --show
-ankiniki config --edit
-ankiniki config --set defaultDeck=MyDeck
+```
+ankiniki note <subcommand>   # card/note operations
+ankiniki deck <subcommand>   # deck management
+ankiniki export              # export to .apkg / CSV / JSON
+ankiniki bundle              # build .apkg offline (no Anki needed)
+ankiniki study               # in-terminal study session
+ankiniki stats               # review statistics
+ankiniki sync                # trigger AnkiWeb sync
+ankiniki status              # check connections
+ankiniki config              # manage settings
 ```
 
-### Options
+### Note commands
 
-#### Add Command
+```bash
+# Add a card
+ankiniki note add "JavaScript" "What is hoisting?" "Moving declarations to the top"
+ankiniki note add --interactive
 
-- `--tags <tags>`: Comma-separated tags
-- `--model <model>`: Card model to use
-- `--interactive`: Interactive mode with editor
+# List cards in a deck
+ankiniki note list "JavaScript"
+ankiniki note list "JavaScript" --limit 20
 
-#### List Command
+# Edit a card
+ankiniki note edit "hoisting"
+ankiniki note edit "tag:js" --deck "JavaScript"
 
-- `--decks`: List all decks (default)
-- `--cards <deck>`: List cards in specific deck
-- `--limit <number>`: Limit results (default: 10)
+# Delete a card by note ID
+ankiniki note delete <noteId>
+ankiniki note delete <noteId> --force
 
-#### Study Command
+# Generate cards with AI from a file
+ankiniki note generate README.md --deck "Docs"
+ankiniki note generate --stdin --deck "Code Review"
 
-- `--count <number>`: Number of cards to study (default: 5)
-- `--random`: Study in random order
+# Import cards from CSV, JSON, or Markdown
+ankiniki note import cards.csv
+ankiniki note import cards.md --preview
 
-#### Config Command
+# Bulk-manage tags
+ankiniki note tag "deck:JavaScript" --add "active" --remove "archived"
+ankiniki note tag "added:7" --add "this-week" --yes
+```
 
-- `--show`: Show current configuration
-- `--edit`: Edit configuration interactively
-- `--set <key=value>`: Set a configuration value
-- `--reset`: Reset to defaults
+### Deck commands
+
+```bash
+ankiniki deck list
+ankiniki deck create "Programming::TypeScript"
+ankiniki deck delete "Old Deck"
+ankiniki deck delete "Old Deck" --force
+```
+
+### Export
+
+```bash
+ankiniki export "JavaScript"                             # → JavaScript.apkg
+ankiniki export "JavaScript" --format csv               # → JavaScript.csv
+ankiniki export "JavaScript" --format json              # → JavaScript.json
+ankiniki export "JavaScript" notes.apkg --include-sched
+ankiniki export "JavaScript" --format csv --query "tag:hard"
+```
+
+### Utility commands
+
+```bash
+ankiniki stats                        # review dashboard
+ankiniki stats --brief                # one-line summary (useful in status bars)
+ankiniki stats --deck "JavaScript"    # scoped to one deck
+
+ankiniki sync                         # trigger AnkiWeb sync
+
+ankiniki status                       # check Anki + backend connections
+
+ankiniki config --show
+ankiniki config --set defaultDeck=JavaScript
+ankiniki config --edit
+
+ankiniki study "JavaScript"
+ankiniki study "JavaScript" --count 20 --random
+```
 
 ## Configuration
 
-The CLI stores configuration in `~/.ankiniki.json`:
+Config is saved at `~/.ankiniki.json`:
 
 ```json
 {
@@ -86,25 +111,6 @@ The CLI stores configuration in `~/.ankiniki.json`:
   "defaultModel": "Basic",
   "debugMode": false
 }
-```
-
-## Examples
-
-```bash
-# Quick card addition
-ankiniki add "JavaScript" "What is hoisting?" "Variable declarations are moved to the top"
-
-# Add with tags
-ankiniki add "React" "What is JSX?" "JavaScript XML syntax" --tags "react,jsx,syntax"
-
-# Interactive mode with editor
-ankiniki add -i
-
-# Study session
-ankiniki study "JavaScript Fundamentals" --count 10 --random
-
-# List recent cards
-ankiniki list --cards "React Concepts" --limit 5
 ```
 
 ## Requirements

--- a/apps/cli/src/__tests__/list.test.ts
+++ b/apps/cli/src/__tests__/list.test.ts
@@ -3,7 +3,6 @@ import { createListCommand } from '../commands/list';
 
 const mockClient = {
   ping: vi.fn().mockResolvedValue(true),
-  getDeckNames: vi.fn().mockResolvedValue(['Default', 'Spanish']),
   findNotes: vi.fn().mockResolvedValue([101, 102, 103]),
   notesInfo: vi.fn().mockResolvedValue([
     {
@@ -37,23 +36,20 @@ vi.mock('../anki-client', () => ({
 }));
 
 vi.mock('ora', () => ({
-  default: vi.fn(() => {
-    return {
-      start: vi.fn().mockReturnThis(),
-      succeed: vi.fn().mockReturnThis(),
-      fail: vi.fn().mockReturnThis(),
-    };
-  }),
+  default: vi.fn(() => ({
+    start: vi.fn().mockReturnThis(),
+    succeed: vi.fn().mockReturnThis(),
+    fail: vi.fn().mockReturnThis(),
+  })),
 }));
 
 const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
 const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
-describe('list command', () => {
+describe('note list command', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockClient.ping.mockResolvedValue(true);
-    mockClient.getDeckNames.mockResolvedValue(['Default', 'Spanish']);
     mockClient.findNotes.mockResolvedValue([101, 102, 103]);
     mockClient.notesInfo.mockResolvedValue([
       {
@@ -80,98 +76,71 @@ describe('list command', () => {
     consoleErrorSpy.mockClear();
   });
 
-  describe('--decks mode (default)', () => {
-    it('lists all decks with note counts', async () => {
-      const cmd = createListCommand();
-      await cmd.parseAsync(['--decks'], { from: 'user' });
+  it('lists cards in the specified deck', async () => {
+    const cmd = createListCommand();
+    await cmd.parseAsync(['Default'], { from: 'user' });
 
-      expect(mockClient.getDeckNames).toHaveBeenCalled();
-      expect(mockClient.findNotes).toHaveBeenCalledTimes(2); // once per deck
+    expect(mockClient.findNotes).toHaveBeenCalledWith('deck:"Default"');
+    expect(mockClient.notesInfo).toHaveBeenCalledWith([101, 102, 103]);
 
-      const output = consoleSpy.mock.calls.map(c => c[0]).join('\n');
-      expect(output).toContain('Default');
-      expect(output).toContain('Spanish');
-    });
-
-    it('defaults to deck listing when no flags provided', async () => {
-      const cmd = createListCommand();
-      await cmd.parseAsync([], { from: 'user' });
-
-      expect(mockClient.getDeckNames).toHaveBeenCalled();
-    });
-
-    it('returns early when AnkiConnect is not reachable', async () => {
-      mockClient.ping.mockResolvedValueOnce(false);
-
-      const cmd = createListCommand();
-      await cmd.parseAsync(['--decks'], { from: 'user' });
-
-      expect(mockClient.getDeckNames).not.toHaveBeenCalled();
-    });
+    const output = consoleSpy.mock.calls.map(c => c[0]).join('\n');
+    expect(output).toContain('What is TypeScript?');
+    expect(output).toContain('What is a closure?');
   });
 
-  describe('--cards mode', () => {
-    it('lists cards in the specified deck', async () => {
-      const cmd = createListCommand();
-      await cmd.parseAsync(['--cards', 'Default'], { from: 'user' });
+  it('shows tags when present', async () => {
+    const cmd = createListCommand();
+    await cmd.parseAsync(['Default'], { from: 'user' });
 
-      expect(mockClient.findNotes).toHaveBeenCalledWith('deck:"Default"');
-      expect(mockClient.notesInfo).toHaveBeenCalledWith([101, 102, 103]);
+    const output = consoleSpy.mock.calls.map(c => c[0]).join('\n');
+    expect(output).toContain('programming');
+    expect(output).toContain('typescript');
+  });
 
-      const output = consoleSpy.mock.calls.map(c => c[0]).join('\n');
-      expect(output).toContain('What is TypeScript?');
-      expect(output).toContain('What is a closure?');
-    });
+  it('shows message when deck has no cards', async () => {
+    mockClient.findNotes.mockResolvedValueOnce([]);
 
-    it('shows tags when present', async () => {
-      const cmd = createListCommand();
-      await cmd.parseAsync(['--cards', 'Default'], { from: 'user' });
+    const cmd = createListCommand();
+    await cmd.parseAsync(['EmptyDeck'], { from: 'user' });
 
-      const output = consoleSpy.mock.calls.map(c => c[0]).join('\n');
-      expect(output).toContain('programming');
-      expect(output).toContain('typescript');
-    });
+    expect(mockClient.notesInfo).not.toHaveBeenCalled();
+  });
 
-    it('shows message when deck has no cards', async () => {
-      mockClient.findNotes.mockResolvedValueOnce([]);
-
-      const cmd = createListCommand();
-      await cmd.parseAsync(['--cards', 'EmptyDeck'], { from: 'user' });
-
-      expect(mockClient.notesInfo).not.toHaveBeenCalled();
-    });
-
-    it('respects --limit option', async () => {
-      mockClient.findNotes.mockResolvedValueOnce([101, 102, 103, 104, 105]);
-      mockClient.notesInfo.mockResolvedValueOnce([
-        {
-          noteId: 101,
-          fields: {
-            Front: { value: 'Q1', order: 0 },
-            Back: { value: 'A1', order: 1 },
-          },
-          tags: [],
+  it('respects --limit option', async () => {
+    mockClient.findNotes.mockResolvedValueOnce([101, 102, 103, 104, 105]);
+    mockClient.notesInfo.mockResolvedValueOnce([
+      {
+        noteId: 101,
+        fields: {
+          Front: { value: 'Q1', order: 0 },
+          Back: { value: 'A1', order: 1 },
         },
-      ]);
+        tags: [],
+      },
+    ]);
 
-      const cmd = createListCommand();
-      await cmd.parseAsync(['--cards', 'Default', '--limit', '1'], {
-        from: 'user',
-      });
+    const cmd = createListCommand();
+    await cmd.parseAsync(['Default', '--limit', '1'], { from: 'user' });
 
-      expect(mockClient.notesInfo).toHaveBeenCalledWith([101]);
-    });
+    expect(mockClient.notesInfo).toHaveBeenCalledWith([101]);
+  });
 
-    it('shows truncation message when there are more cards than the limit', async () => {
-      mockClient.findNotes.mockResolvedValueOnce([101, 102, 103, 104, 105]);
+  it('shows truncation message when there are more cards than the limit', async () => {
+    mockClient.findNotes.mockResolvedValueOnce([101, 102, 103, 104, 105]);
 
-      const cmd = createListCommand();
-      await cmd.parseAsync(['--cards', 'Default', '--limit', '2'], {
-        from: 'user',
-      });
+    const cmd = createListCommand();
+    await cmd.parseAsync(['Default', '--limit', '2'], { from: 'user' });
 
-      const output = consoleSpy.mock.calls.map(c => c[0]).join('\n');
-      expect(output).toContain('more cards');
-    });
+    const output = consoleSpy.mock.calls.map(c => c[0]).join('\n');
+    expect(output).toContain('more cards');
+  });
+
+  it('returns early when AnkiConnect is not reachable', async () => {
+    mockClient.ping.mockResolvedValueOnce(false);
+
+    const cmd = createListCommand();
+    await cmd.parseAsync(['Default'], { from: 'user' });
+
+    expect(mockClient.findNotes).not.toHaveBeenCalled();
   });
 });

--- a/apps/cli/src/commands/list.ts
+++ b/apps/cli/src/commands/list.ts
@@ -8,11 +8,10 @@ export function createListCommand(): Command {
   const command = new Command('list');
 
   command
-    .description('List decks or cards')
-    .option('-d, --decks', 'List all decks')
-    .option('-c, --cards <deck>', 'List cards in a specific deck')
+    .description('List cards in a deck')
+    .argument('<deck>', 'Deck name to list cards from')
     .option('-l, --limit <number>', 'Limit number of results', '10')
-    .action(async options => {
+    .action(async (deck: string, options: { limit: string }) => {
       const client = new AnkiClient();
 
       try {
@@ -25,13 +24,7 @@ export function createListCommand(): Command {
         }
         spinner.succeed(ANKI_MESSAGES.CONNECTED);
 
-        if (options.cards) {
-          // List cards in specific deck
-          await listCards(client, options.cards, parseInt(options.limit));
-        } else {
-          // List decks (default)
-          await listDecks(client);
-        }
+        await listCards(client, deck, parseInt(options.limit));
       } catch (error: any) {
         console.error(chalk.red(`Error: ${error.message}`));
         process.exit(1);
@@ -39,30 +32,6 @@ export function createListCommand(): Command {
     });
 
   return command;
-}
-
-async function listDecks(client: AnkiClient): Promise<void> {
-  const spinner = ora('Loading decks...').start();
-
-  try {
-    const deckNames = await client.getDeckNames();
-    spinner.succeed(`Found ${deckNames.length} decks`);
-
-    console.log(chalk.bold('\n📚 Available Decks:'));
-
-    for (const [index, deckName] of deckNames.entries()) {
-      // Get card count for each deck
-      const noteIds = await client.findNotes(`deck:"${deckName}"`);
-      const cardCount = noteIds.length;
-
-      console.log(
-        `${chalk.cyan(`${index + 1}.`)} ${chalk.white(deckName)} ${chalk.gray(`(${cardCount} cards)`)}`
-      );
-    }
-  } catch (error) {
-    spinner.fail('Failed to load decks');
-    throw error;
-  }
 }
 
 async function listCards(

--- a/apps/cli/src/commands/note.ts
+++ b/apps/cli/src/commands/note.ts
@@ -1,0 +1,28 @@
+/**
+ * Note command group - All note/card operations
+ */
+
+import { Command } from 'commander';
+import { createAddCommand } from './add';
+import { createListCommand } from './list';
+import { createEditCommand } from './edit';
+import { createDeleteCommand } from './delete';
+import { createGenerateCommand } from './generate';
+import { importCommand } from './import';
+import { createTagCommand } from './tag';
+
+export function createNoteCommand(): Command {
+  const command = new Command('note');
+
+  command.description('Create, read, update, and delete notes/cards');
+
+  command.addCommand(createAddCommand());
+  command.addCommand(createListCommand());
+  command.addCommand(createEditCommand());
+  command.addCommand(createDeleteCommand());
+  command.addCommand(createGenerateCommand());
+  command.addCommand(importCommand);
+  command.addCommand(createTagCommand());
+
+  return command;
+}

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -2,21 +2,15 @@
 
 import { Command } from 'commander';
 import chalk from 'chalk';
-import { createAddCommand } from './commands/add';
-import { createListCommand } from './commands/list';
-import { createConfigCommand } from './commands/config';
-import { createStudyCommand } from './commands/study';
-import { importCommand } from './commands/import';
+import { createNoteCommand } from './commands/note';
 import { createDeckCommand } from './commands/deck';
-import { createDeleteCommand } from './commands/delete';
 import { createExportCommand } from './commands/export';
 import { createBundleCommand } from './commands/bundle';
-import { createEditCommand } from './commands/edit';
-import { createGenerateCommand } from './commands/generate';
+import { createStudyCommand } from './commands/study';
+import { createConfigCommand } from './commands/config';
 import { createStatusCommand } from './commands/status';
 import { createSyncCommand } from './commands/sync';
 import { createStatsCommand } from './commands/stats';
-import { createTagCommand } from './commands/tag';
 import { APP_CONFIG } from '@ankiniki/shared';
 
 const program = new Command();
@@ -26,22 +20,22 @@ program
   .description(APP_CONFIG.DESCRIPTION)
   .version(APP_CONFIG.VERSION);
 
-// Add subcommands
-program.addCommand(createAddCommand());
-program.addCommand(createListCommand());
-program.addCommand(createStudyCommand());
-program.addCommand(createConfigCommand());
-program.addCommand(importCommand);
+// Note operations
+program.addCommand(createNoteCommand());
+
+// Deck operations
 program.addCommand(createDeckCommand());
-program.addCommand(createDeleteCommand());
+
+// Import/export
 program.addCommand(createExportCommand());
 program.addCommand(createBundleCommand());
-program.addCommand(createEditCommand());
-program.addCommand(createGenerateCommand());
+
+// Utility
+program.addCommand(createStudyCommand());
+program.addCommand(createConfigCommand());
 program.addCommand(createStatusCommand());
 program.addCommand(createSyncCommand());
 program.addCommand(createStatsCommand());
-program.addCommand(createTagCommand());
 
 // Global error handling
 process.on('unhandledRejection', error => {

--- a/docs/ja/user-guides/cli/README.md
+++ b/docs/ja/user-guides/cli/README.md
@@ -13,7 +13,7 @@ CLI を使用する前に以下が必要です。
 1. **Anki デスクトップアプリ**が起動していること
 2. **AnkiConnect アドオン**が Anki にインストールされていること（コード: `2055492159`）
    - Anki → ツール → アドオン → アドオンを取得 → コードを入力
-3. **Ankiniki バックエンドサーバー**が起動していること（import コマンドで必要）
+3. **Ankiniki バックエンドサーバー**が起動していること（`note import` / `note generate` で必要）
    ```bash
    # プロジェクトルートから
    npm run dev --workspace=@ankiniki/backend
@@ -42,13 +42,14 @@ node apps/cli/dist/index.js <コマンド>
 
 ```bash
 # 接続確認
+ankiniki status
 ankiniki config --show
 
 # はじめてのカードを追加
-ankiniki add "My Deck" "クロージャとは？" "外側のスコープの変数を参照する関数"
+ankiniki note add "My Deck" "クロージャとは？" "外側のスコープの変数を参照する関数"
 
-# デッキ一覧を表示
-ankiniki list
+# デッキ内のカードを表示
+ankiniki note list "My Deck"
 
 # デッキを学習する
 ankiniki study "My Deck"
@@ -56,36 +57,58 @@ ankiniki study "My Deck"
 
 ---
 
-## コマンド一覧
+## コマンド概要
 
-### `add` — フラッシュカードを作成
+コマンドは **`note`**（カード操作）と **`deck`**（デッキ管理）の2グループと、単独のユーティリティコマンドに分かれています。
 
-**基本形:**
+```
+ankiniki note add        カードを作成
+ankiniki note list       デッキ内のカードを一覧表示
+ankiniki note edit       $EDITOR でカードを編集
+ankiniki note delete     Note ID でカードを削除
+ankiniki note generate   AI でファイルまたは stdin からカードを生成
+ankiniki note import     CSV / JSON / Markdown から一括インポート
+ankiniki note tag        マッチしたノートのタグを一括追加・削除
+
+ankiniki deck list       デッキ一覧（カード数つき）
+ankiniki deck create     デッキを作成
+ankiniki deck delete     デッキとカードを削除
+
+ankiniki export          デッキを .apkg / CSV / JSON でエクスポート
+ankiniki bundle          Anki 不要で .apkg をオフライン作成
+ankiniki study           ターミナルで学習セッション
+ankiniki stats           レビュー統計ダッシュボード
+ankiniki sync            AnkiWeb 同期を実行
+ankiniki status          Anki・バックエンドの接続確認
+ankiniki config          設定管理
+```
+
+---
+
+## `note add` — フラッシュカードを作成
 
 ```bash
-ankiniki add [デッキ名] [表面] [裏面]
+ankiniki note add [デッキ名] [表面] [裏面]
 ```
 
 **使用例:**
 
 ```bash
 # 引数で直接指定（最速）
-ankiniki add "JavaScript" "ホイスティングとは？" "宣言をスコープの先頭に移動する動作"
+ankiniki note add "JavaScript" "ホイスティングとは？" "宣言をスコープの先頭に移動する動作"
 
 # タグとモデルを指定
-ankiniki add "Rust" "所有権とは？" "各値には必ず1つの所有者がある" \
+ankiniki note add "Rust" "所有権とは？" "各値には必ず1つの所有者がある" \
   --tags "rust,memory,ownership" \
   --model "Basic"
 
 # デフォルトデッキを使用（config で設定済みの場合）
-ankiniki add "モナドとは？" "自己関手の圏におけるモノイド対象"
+ankiniki note add "モナドとは？" "自己関手の圏におけるモノイド対象"
 
 # インタラクティブモード — すべてを対話形式で入力
-ankiniki add --interactive
-ankiniki add -i
+ankiniki note add --interactive
+ankiniki note add -i
 ```
-
-**オプション一覧:**
 
 | オプション        | 短縮形 | 説明                              |
 | ----------------- | ------ | --------------------------------- |
@@ -93,183 +116,128 @@ ankiniki add -i
 | `--model <model>` | `-m`   | カードモデル（デフォルト: Basic） |
 | `--interactive`   | `-i`   | 対話形式で入力                    |
 
-**インタラクティブモード**では表面・裏面の入力に `$EDITOR` が開きます。複数行のコードスニペットを書くときに便利です。
-
 ---
 
-### `study` — ターミナルで学習セッション
-
-表面を表示 → Enter で裏面を表示 → 1〜4で評価、という流れで学習します。
+## `note list` — デッキ内のカードを表示
 
 ```bash
-ankiniki study [デッキ名]
+ankiniki note list <デッキ名> [--limit <n>]
 ```
 
 **使用例:**
 
 ```bash
-# 特定のデッキを学習（デフォルト5枚）
-ankiniki study "JavaScript"
-
-# 20枚をランダム順で学習
-ankiniki study "JavaScript" --count 20 --random
-ankiniki study "JavaScript" -n 20 --random
-
-# デッキ名を省略すると選択肢が表示される
-ankiniki study
+ankiniki note list "JavaScript"
+ankiniki note list "JavaScript" --limit 50
 ```
 
-**オプション一覧:**
-
-| オプション    | 短縮形 | 説明                      |
-| ------------- | ------ | ------------------------- |
-| `--count <n>` | `-n`   | 学習枚数（デフォルト: 5） |
-| `--random`    |        | カードをシャッフル        |
-
-**評価基準:**
-
-| 選択肢   | 意味                 |
-| -------- | -------------------- |
-| ❌ Again | わからなかった       |
-| 🔶 Hard  | わかったが難しかった |
-| ✅ Good  | わかった             |
-| 🚀 Easy  | 簡単すぎた           |
-
-> **注意:** このモードは Anki のスケジューリングに関係なく、デッキ内のカードを取得します。Anki の間隔反復スケジュールに従って学習する場合は、Anki デスクトップで通常どおりレビューしてください。
+| オプション    | 短縮形 | 説明                           |
+| ------------- | ------ | ------------------------------ |
+| `--limit <n>` | `-l`   | 表示件数上限（デフォルト: 10） |
 
 ---
 
-### `list` — デッキとカードの一覧表示
+## `note edit` — カードを編集
+
+クエリでノートを検索し、一覧から選んで `$EDITOR` でフィールドを編集します。
 
 ```bash
-ankiniki list                          # デッキ一覧（デフォルト）
-ankiniki list --decks                  # 同上
-ankiniki list --cards "My Deck"        # デッキ内のカードを表示
-ankiniki list --cards "My Deck" --limit 50
+ankiniki note edit <クエリ> [--deck <デッキ名>] [--limit <n>]
 ```
 
 **使用例:**
 
 ```bash
-# 全デッキをカード数つきで表示
-ankiniki list
-
-# デッキ内のカードを確認（最初の10枚）
-ankiniki list --cards "JavaScript"
-
-# より多く表示
-ankiniki list --cards "JavaScript" --limit 50
+ankiniki note edit "ホイスティング"
+ankiniki note edit "tag:js" --deck "JavaScript"
+ankiniki note edit "added:1" --limit 5
 ```
-
-**オプション一覧:**
-
-| オプション         | 短縮形 | 説明                           |
-| ------------------ | ------ | ------------------------------ |
-| `--decks`          | `-d`   | デッキ一覧を表示               |
-| `--cards <デッキ>` | `-c`   | デッキ内のカードを表示         |
-| `--limit <n>`      | `-l`   | 表示件数上限（デフォルト: 10） |
 
 ---
 
-### `config` — 設定管理
+## `note delete` — カードを削除
 
 ```bash
-ankiniki config               # 現在の設定を表示（デフォルト）
-ankiniki config --show
-ankiniki config --edit        # 対話形式で編集
-ankiniki config --set key=value
-ankiniki config --reset       # デフォルトに戻す
+ankiniki note delete <noteId> [--force]
 ```
 
-**設定項目:**
+Note ID は `ankiniki note list <デッキ>` で確認できます。
 
-| キー             | デフォルト値            | 説明                                           |
-| ---------------- | ----------------------- | ---------------------------------------------- |
-| `ankiConnectUrl` | `http://localhost:8765` | AnkiConnect API のエンドポイント               |
-| `serverUrl`      | `http://localhost:3001` | Ankiniki バックエンド（import コマンドで使用） |
-| `defaultDeck`    | `Default`               | デッキ未指定時に使用するデッキ名               |
-| `defaultModel`   | `Basic`                 | モデル未指定時に使用するカードモデル           |
-| `debugMode`      | `false`                 | 詳細ログ出力                                   |
+```bash
+ankiniki note list "JavaScript"
+# → 1. Card ID: 1700000001
+#      Front: ホイスティングとは？
+
+ankiniki note delete 1700000001
+ankiniki note delete 1700000001 --force   # 確認をスキップ
+```
+
+---
+
+## `note generate` — AI でカードを生成
+
+ファイルまたはパイプ経由のコンテンツから AI バックエンドを使ってカードを生成します。
+
+```bash
+ankiniki note generate <ファイル>   [オプション]
+ankiniki note generate --stdin      [オプション]
+```
 
 **使用例:**
 
 ```bash
-# 現在の設定と接続状態を確認
-ankiniki config --show
+# ファイルから生成（拡張子からコンテンツタイプを自動判別）
+ankiniki note generate README.md --deck "Docs"
+ankiniki note generate src/auth.ts --deck "Code" --lang typescript
 
-# デフォルトデッキを変更
-ankiniki config --set defaultDeck=JavaScript
+# stdin から読み込む
+cat CHANGELOG.md | ankiniki note generate --stdin --deck "Releases"
+git diff HEAD~1 | ankiniki note generate --stdin --content-type code --deck "Review"
 
-# バックエンドの URL を変更
-ankiniki config --set serverUrl=http://localhost:3001
-
-# 対話形式で編集（デッキ・モデルの選択肢が表示される）
-ankiniki config --edit
-
-# すべての設定をデフォルトに戻す
-ankiniki config --reset
+# 確認なしで全カードを追加
+ankiniki note generate README.md --deck "Docs" --yes
 ```
 
-設定は `~/.ankiniki.json` に保存されます。
+| オプション              | 短縮形 | 説明                                           |
+| ----------------------- | ------ | ---------------------------------------------- |
+| `--stdin`               |        | stdin からコンテンツを読み込む                 |
+| `--deck <deck>`         | `-d`   | 対象デッキ                                     |
+| `--content-type <type>` | `-t`   | `code` / `markdown` / `text`（自動判別）       |
+| `--difficulty <level>`  |        | `beginner` / `intermediate` / `advanced`       |
+| `--max-cards <n>`       | `-n`   | 生成する最大カード数（デフォルト: 5）          |
+| `--lang <language>`     |        | プログラミング言語のヒント（コードファイル用） |
+| `--tags <tags>`         |        | 追加タグ（カンマ区切り）                       |
+| `--yes`                 | `-y`   | 確認なしで全カードを追加                       |
 
 ---
 
-### `import` — ファイルから一括インポート
+## `note import` — ファイルから一括インポート
 
-CSV・JSON・Markdown ファイルから複数のカードを一度にインポートします。**ファイル拡張子から形式が自動判別されます。**
-
-```bash
-ankiniki import <ファイル> [オプション]
-```
-
-#### CSV インポート
+**ファイル拡張子から形式が自動判別されます**（`.csv`, `.json`, `.md`）。
 
 ```bash
-# 拡張子 .csv から自動判別
-ankiniki import cards.csv
-
-# プレビュー（カードは作成されない）
-ankiniki import cards.csv --preview
-
-# デフォルトデッキとタグを指定
-ankiniki import cards.csv --deck "JavaScript" --tags "imported,js"
+ankiniki note import <ファイル> [オプション]
 ```
 
-**CSV 形式:**
+### CSV
+
+```bash
+ankiniki note import cards.csv
+ankiniki note import cards.csv --preview
+ankiniki note import cards.csv --deck "JavaScript" --tags "imported,js"
+```
 
 ```csv
 Front,Back,Deck,Tags,Model
 "クロージャとは？","外側のスコープの変数を参照する関数","JavaScript","js,closures","Basic"
-"ホイスティングとは？","宣言をスコープの先頭に移動する動作","JavaScript","js","Basic"
 ```
 
-シンプルな形式（デッキ・タグは CLI フラグで指定）:
-
-```csv
-Front,Back
-"クロージャとは？","外側のスコープの変数を参照する関数"
-```
-
-カスタム列名を使う場合:
+### JSON
 
 ```bash
-ankiniki import cards.csv \
-  --mapping '{"front":"質問","back":"回答","deck":"教科","tags":"タグ"}'
+ankiniki note import cards.json
+ankiniki note import cards.json --deck "Rust"
 ```
-
----
-
-#### JSON インポート
-
-```bash
-# 拡張子 .json から自動判別
-ankiniki import cards.json
-
-ankiniki import cards.json --preview
-ankiniki import cards.json --deck "Rust" --tags "rust"
-```
-
-**JSON 形式（配列）:**
 
 ```json
 [
@@ -278,43 +246,16 @@ ankiniki import cards.json --deck "Rust" --tags "rust"
     "back": "Rust では各値に必ず1つの所有者がある。",
     "deck": "Rust",
     "tags": ["rust", "memory"]
-  },
-  {
-    "front": "借用とは？",
-    "back": "所有権を移さずに値を一時的に使うこと。",
-    "deck": "Rust",
-    "tags": ["rust", "memory"]
   }
 ]
 ```
 
-**JSON 形式（デフォルト値つきオブジェクト）:**
-
-```json
-{
-  "deck_name": "Rust",
-  "default_tags": ["rust"],
-  "default_model": "Basic",
-  "cards": [
-    { "front": "所有権とは？", "back": "各値に必ず1つの所有者がある。" },
-    { "front": "借用とは？", "back": "所有権を移さずに値を一時的に使うこと。" }
-  ]
-}
-```
-
----
-
-#### Markdown インポート
+### Markdown
 
 ```bash
-# 拡張子 .md から自動判別
-ankiniki import cards.md
-
-ankiniki import cards.md --preview
-ankiniki import cards.md --deck "TypeScript"
+ankiniki note import cards.md
+ankiniki note import cards.md --preview
 ```
-
-**Markdown 形式:**
 
 ```markdown
 ---
@@ -322,121 +263,124 @@ deck: Programming::TypeScript
 tags: [typescript, types]
 ---
 
-## 型アサーションとは？
-
-**Front:** TypeScript における型アサーションとは何ですか？
-**Back:** コンパイラに対して「この値はこの型として扱え」と指示する構文。`as` または `<Type>` を使う。
-
 ## ユニオン型とは？
 
 **Front:** ユニオン型とは何ですか？
 **Back:** 複数の型のいずれかを取れる型。`A | B` のように書く。
 ```
 
-- フロントマター（`---` ブロック）でデフォルトのデッキとタグを設定
-- `##` 見出しごとに1枚のカード
-- 各セクションに `**Front:**` と `**Back:**` が必要
+### 共通オプション
+
+| オプション           | 短縮形 | 説明                                    |
+| -------------------- | ------ | --------------------------------------- |
+| `--format <fmt>`     | `-f`   | 形式を強制: `csv` / `json` / `markdown` |
+| `--deck <デッキ>`    |        | デフォルトデッキ                        |
+| `--model <モデル>`   |        | カードモデル（デフォルト: Basic）       |
+| `--tags <タグ>`      |        | 追加タグ（カンマ区切り）                |
+| `--preview`          | `-p`   | ドライラン（実際にはインポートしない）  |
+| `--delimiter <文字>` | `-d`   | CSV 区切り文字（デフォルト: `,`）       |
+| `--mapping <json>`   |        | CSV カスタム列マッピング                |
 
 ---
 
-#### インポート共通オプション
+## `note tag` — タグの一括管理
 
-| オプション           | 短縮形 | 説明                                         |
-| -------------------- | ------ | -------------------------------------------- |
-| `--format <fmt>`     | `-f`   | 形式を強制指定: `csv` / `json` / `markdown`  |
-| `--deck <デッキ>`    |        | デフォルトデッキ（ファイル内の設定を上書き） |
-| `--model <モデル>`   |        | カードモデル（デフォルト: Basic）            |
-| `--tags <タグ>`      |        | 追加タグ（カンマ区切り）                     |
-| `--preview`          | `-p`   | ドライラン — 実際にはインポートしない        |
-| `--dry-run`          |        | `--preview` と同じ                           |
-| `--delimiter <文字>` | `-d`   | CSV 区切り文字（デフォルト: `,`）            |
-| `--mapping <json>`   |        | CSV カスタム列マッピング                     |
-
----
-
-### `import mapping` — 形式サンプルを表示
+AnkiConnect クエリにマッチするノートにタグをまとめて追加・削除します。
 
 ```bash
-ankiniki import mapping
-```
-
----
-
-### `deck` — デッキ管理
-
-```bash
-ankiniki deck list                   # デッキ一覧をカード数つきで表示
-ankiniki deck create <name>          # デッキを作成
-ankiniki deck delete <name>          # デッキを削除（確認プロンプトあり）
-ankiniki deck delete <name> --force  # 確認をスキップして削除
+ankiniki note tag <クエリ> --add <タグ> [--remove <タグ>] [--deck <デッキ名>] [--yes]
 ```
 
 **使用例:**
 
 ```bash
-# デッキ一覧を確認
+# デッキ内の全ノートにタグを付ける
+ankiniki note tag "deck:Japanese" --add "n+1,active"
+
+# タグを一括リネーム
+ankiniki note tag "tag:old-tag" --remove "old-tag" --add "new-tag" --yes
+
+# 今週追加したノートにタグを付ける
+ankiniki note tag "added:7" --add "this-week" --yes
+```
+
+---
+
+## `deck` — デッキ管理
+
+```bash
 ankiniki deck list
-
-# ネストしたデッキを作成
 ankiniki deck create "Programming::TypeScript"
-
-# デッキを削除
 ankiniki deck delete "古いデッキ"
+ankiniki deck delete "古いデッキ" --force
 ```
 
-> `ankiniki deck delete` はデッキ内の**すべてのカードも削除**します。デフォルトで確認プロンプトが表示されます。
+> `deck delete` はデッキ内の**すべてのカードも削除**します。デフォルトで確認プロンプトが表示されます。
 
 ---
 
-### `delete` — カードを削除
+## `export` — デッキをエクスポート
 
 ```bash
-ankiniki delete <noteId>           # カードのプレビューを表示して確認
-ankiniki delete <noteId> --force   # 確認をスキップして削除
+ankiniki export <デッキ名> [出力先] [--format apkg|csv|json] [--query <クエリ>] [--include-sched]
 ```
 
-Note ID は `ankiniki list --cards <デッキ>` で確認できます。
+| 形式   | 説明                                                    |
+| ------ | ------------------------------------------------------- |
+| `apkg` | Anki パッケージ — Anki に直接インポート可（デフォルト） |
+| `csv`  | スプレッドシート向け（全フィールド + タグ）             |
+| `json` | ノートオブジェクトの JSON 配列                          |
 
 **使用例:**
 
 ```bash
-# まず Note ID を確認
-ankiniki list --cards "JavaScript"
-# → 1. Card ID: 1700000001
-#      Front: ホイスティングとは？
-
-# 削除
-ankiniki delete 1700000001
+ankiniki export "JavaScript"                              # → JavaScript.apkg
+ankiniki export "JavaScript" --format csv                 # → JavaScript.csv
+ankiniki export "JavaScript" --format json                # → JavaScript.json
+ankiniki export "JavaScript" notes.apkg --include-sched
+ankiniki export "JavaScript" --format csv --query "tag:hard"
 ```
 
 ---
 
-### `export` — デッキを `.apkg` としてエクスポート
+## `stats` — レビュー統計
 
 ```bash
-ankiniki export <デッキ名> [出力先]
+ankiniki stats                     # 全体ダッシュボード
+ankiniki stats --brief             # 1行サマリー（ステータスバー向け）
+ankiniki stats --deck "JavaScript" # 特定デッキに絞り込み
 ```
 
-**使用例:**
+---
+
+## `sync` — AnkiWeb 同期
 
 ```bash
-# カレントディレクトリに保存（JavaScript.apkg として保存）
-ankiniki export "JavaScript"
-
-# 保存先を指定
-ankiniki export "Programming::Rust" ~/backups/rust.apkg
-
-# 学習履歴・スケジューリングデータも含める
-ankiniki export "JavaScript" --include-sched
+ankiniki sync
 ```
 
-**オプション:**
+Anki 内蔵の「同期」ボタンと同じ動作。AnkiWeb アカウントが Anki に設定されている必要があります。
 
-| オプション        | 説明                                      |
-| ----------------- | ----------------------------------------- |
-| `--include-sched` | Anki のスケジューリングと学習履歴を含める |
+---
 
-エクスポートした `.apkg` ファイルは、Anki の「ファイル → インポート」から任意の Anki 環境にインポートできます。
+## `config` — 設定管理
+
+```bash
+ankiniki config --show
+ankiniki config --set defaultDeck=JavaScript
+ankiniki config --edit
+ankiniki config --reset
+```
+
+| キー             | デフォルト値            | 説明                                              |
+| ---------------- | ----------------------- | ------------------------------------------------- |
+| `ankiConnectUrl` | `http://localhost:8765` | AnkiConnect API のエンドポイント                  |
+| `serverUrl`      | `http://localhost:3001` | Ankiniki バックエンド（import / generate で使用） |
+| `defaultDeck`    | `Default`               | デッキ未指定時に使用するデッキ名                  |
+| `defaultModel`   | `Basic`                 | モデル未指定時に使用するカードモデル              |
+| `debugMode`      | `false`                 | 詳細ログ出力                                      |
+
+設定は `~/.ankiniki.json` に保存されます。
 
 ---
 
@@ -445,57 +389,41 @@ ankiniki export "JavaScript" --include-sched
 ### コーディング中にその場でカードを追加する
 
 ```bash
-# Rust を調べていて気づいたことをすぐ追加
-ankiniki add "Rust" \
+ankiniki note add "Rust" \
   "Option::unwrap_or_else は何をする？" \
   "値を返す。値がなければクロージャを呼んでフォールバック値を計算する。" \
-  --tags "rust,option,error-handling"
-
-# 追加されたか確認
-ankiniki list --cards "Rust"
+  --tags "rust,option"
 ```
 
 ### 読書ノートを一括インポート
 
 ```bash
-# ドキュメントを読みながら Markdown でカードを書いて、まとめてインポート
-ankiniki import study-notes.md --preview   # まずプレビューで確認
-ankiniki import study-notes.md
+ankiniki note import study-notes.md --preview
+ankiniki note import study-notes.md
+```
+
+### PR の差分から AI でカードを生成
+
+```bash
+git diff main | ankiniki note generate --stdin --content-type code --deck "Review" --yes
 ```
 
 ### ターミナルで毎日のレビュー
 
 ```bash
-# メインデッキからランダムに10枚
 ankiniki study "Programming" --count 10 --random
 ```
 
-### デッキをバックアップ・共有する
+### デッキをバックアップ
 
 ```bash
-# 同僚への共有や別マシンへの移行のためにエクスポート
-ankiniki export "Programming::Rust" rust-deck.apkg
-
-# 学習履歴（進捗・スケジュール）も含める
 ankiniki export "Programming::Rust" rust-deck.apkg --include-sched
-# 移行先での取り込み: Anki → ファイル → インポート → rust-deck.apkg を選択
 ```
 
-### 不要なカードを削除する
+### タグを一括リネーム
 
 ```bash
-# カード一覧で Note ID を確認
-ankiniki list --cards "JavaScript" --limit 50
-
-# Note ID を指定して削除
-ankiniki delete 1700000001
-```
-
-### 新しいマシンでの設定
-
-```bash
-ankiniki config --edit   # ankiConnectUrl, serverUrl, defaultDeck を設定
-ankiniki config --show   # 接続確認
+ankiniki note tag "deck:Japanese" --remove "todo" --add "done" --yes
 ```
 
 ---
@@ -505,8 +433,8 @@ ankiniki config --show   # 接続確認
 | 問題                       | 解決策                                                                                  |
 | -------------------------- | --------------------------------------------------------------------------------------- |
 | `Cannot connect to Anki`   | Anki デスクトップが起動しているか、AnkiConnect がインストールされているか確認           |
-| `Deck does not exist`      | Anki でデッキを先に作成するか、デッキ名のスペルを確認                                   |
+| `Deck does not exist`      | `ankiniki deck create "<name>"` でデッキを作成するか、デッキ名のスペルを確認            |
 | `Import failed: API Error` | バックエンドサーバーが起動しているか確認（`npm run dev --workspace=@ankiniki/backend`） |
-| `Model does not exist`     | `ankiniki list` でモデル名を確認するか、`Basic` を使用                                  |
+| `Model does not exist`     | Anki デスクトップの設定でモデル名を確認するか、`Basic` を使用                           |
 
 AnkiConnect の動作確認: ブラウザで `http://localhost:8765` を開くとバージョン番号が表示されます。

--- a/docs/user-guides/cli/README.md
+++ b/docs/user-guides/cli/README.md
@@ -13,7 +13,7 @@ Before using the CLI you need:
 1. **Anki desktop** running on your machine
 2. **AnkiConnect addon** installed in Anki (code: `2055492159`)
    - Anki → Tools → Add-ons → Get Add-ons → enter the code
-3. **Ankiniki backend server** running (for import commands)
+3. **Ankiniki backend server** running (for `note import` and `note generate`)
    ```bash
    # From the project root
    npm run dev --workspace=@ankiniki/backend
@@ -42,13 +42,14 @@ node apps/cli/dist/index.js <command>
 
 ```bash
 # Check everything is working
+ankiniki status
 ankiniki config --show
 
 # Add your first card
-ankiniki add "My Deck" "What is a closure?" "A function that captures its enclosing scope"
+ankiniki note add "My Deck" "What is a closure?" "A function that captures its enclosing scope"
 
-# List your decks
-ankiniki list
+# List cards in a deck
+ankiniki note list "My Deck"
 
 # Study a deck
 ankiniki study "My Deck"
@@ -56,36 +57,58 @@ ankiniki study "My Deck"
 
 ---
 
-## Commands
+## Command overview
 
-### `add` — Create a flashcard
+Commands are grouped into two main areas — **`note`** for card operations and **`deck`** for deck management — plus standalone utility commands.
 
-**One-liner:**
+```
+ankiniki note add        Create a new flashcard
+ankiniki note list       List cards in a deck
+ankiniki note edit       Edit a card in $EDITOR
+ankiniki note delete     Delete a card by note ID
+ankiniki note generate   AI-generate cards from a file or stdin
+ankiniki note import     Bulk import from CSV / JSON / Markdown
+ankiniki note tag        Bulk add/remove tags on matched notes
+
+ankiniki deck list       List all decks with card counts
+ankiniki deck create     Create a new deck
+ankiniki deck delete     Delete a deck and its cards
+
+ankiniki export          Export a deck to .apkg / CSV / JSON
+ankiniki bundle          Build .apkg offline (no Anki required)
+ankiniki study           In-terminal study session
+ankiniki stats           Review statistics dashboard
+ankiniki sync            Trigger AnkiWeb sync
+ankiniki status          Check Anki + backend connections
+ankiniki config          Manage settings
+```
+
+---
+
+## `note add` — Create a flashcard
 
 ```bash
-ankiniki add [deck] [front] [back]
+ankiniki note add [deck] [front] [back]
 ```
 
 **Examples:**
 
 ```bash
 # Positional arguments (fastest)
-ankiniki add "JavaScript" "What is hoisting?" "Moving declarations to the top of scope"
+ankiniki note add "JavaScript" "What is hoisting?" "Moving declarations to the top of scope"
 
 # With tags and model
-ankiniki add "Rust" "What is ownership?" "Each value has one owner" \
+ankiniki note add "Rust" "What is ownership?" "Each value has one owner" \
   --tags "rust,memory,ownership" \
   --model "Basic"
 
 # Use default deck (set via config)
-ankiniki add "What is a monad?" "A monoid in the category of endofunctors"
+ankiniki note add "What is a monad?" "A monoid in the category of endofunctors"
 
 # Interactive mode — prompts for everything
-ankiniki add --interactive
-ankiniki add -i
+ankiniki note add --interactive
+ankiniki note add -i
 ```
-
-**Options:**
 
 | Option            | Short | Description                        |
 | ----------------- | ----- | ---------------------------------- |
@@ -93,146 +116,120 @@ ankiniki add -i
 | `--model <model>` | `-m`  | Card model (default: Basic)        |
 | `--interactive`   | `-i`  | Interactive prompts for all fields |
 
-**Interactive mode** opens your `$EDITOR` for front/back content — useful for multi-line code snippets.
-
 ---
 
-### `study` — Quick study session
-
-Starts an in-terminal study session: shows the front, waits for Enter, reveals the back, asks you to rate 1–4.
+## `note list` — Browse cards in a deck
 
 ```bash
-ankiniki study [deck]
+ankiniki note list <deck> [--limit <n>]
 ```
 
 **Examples:**
 
 ```bash
-# Study a specific deck (5 cards by default)
-ankiniki study "JavaScript"
-
-# Study 20 cards in random order
-ankiniki study "JavaScript" --count 20 --random
-ankiniki study "JavaScript" -n 20 --random
-
-# Omit deck to pick from a list
-ankiniki study
+ankiniki note list "JavaScript"
+ankiniki note list "JavaScript" --limit 50
 ```
 
-**Options:**
-
-| Option        | Short | Description                           |
-| ------------- | ----- | ------------------------------------- |
-| `--count <n>` | `-n`  | Number of cards to study (default: 5) |
-| `--random`    |       | Shuffle cards                         |
-
-**Rating scale:**
-
-| Choice   | Meaning               |
-| -------- | --------------------- |
-| ❌ Again | Didn't know it        |
-| 🔶 Hard  | Got it, but difficult |
-| ✅ Good  | Knew it               |
-| 🚀 Easy  | Too easy              |
-
-> **Note:** This mode picks cards from the deck regardless of Anki's scheduling. To use Anki's spaced repetition schedule, review cards in Anki desktop as usual.
+| Option        | Short | Description               |
+| ------------- | ----- | ------------------------- |
+| `--limit <n>` | `-l`  | Max results (default: 10) |
 
 ---
 
-### `list` — Browse decks and cards
+## `note edit` — Edit a card
+
+Search for notes by query, pick from the results, then edit fields in `$EDITOR`.
 
 ```bash
-ankiniki list                        # list all decks (default)
-ankiniki list --decks                # same as above
-ankiniki list --cards "My Deck"      # list cards in a deck
-ankiniki list --cards "My Deck" --limit 50
+ankiniki note edit <query> [--deck <name>] [--limit <n>]
 ```
 
 **Examples:**
 
 ```bash
-# See all decks with card counts
-ankiniki list
+# Find by keyword
+ankiniki note edit "hoisting"
 
-# Browse cards in a deck (first 10)
-ankiniki list --cards "JavaScript"
+# Scope to a deck
+ankiniki note edit "tag:js" --deck "JavaScript"
 
-# See more cards
-ankiniki list --cards "JavaScript" --limit 50
+# Cap results shown in picker
+ankiniki note edit "added:1" --limit 5
 ```
-
-**Options:**
-
-| Option           | Short | Description               |
-| ---------------- | ----- | ------------------------- |
-| `--decks`        | `-d`  | List all decks            |
-| `--cards <deck>` | `-c`  | List cards in deck        |
-| `--limit <n>`    | `-l`  | Max results (default: 10) |
 
 ---
 
-### `config` — Manage settings
+## `note delete` — Remove a card
 
 ```bash
-ankiniki config               # show current config (default)
-ankiniki config --show
-ankiniki config --edit        # interactive editor
-ankiniki config --set key=value
-ankiniki config --reset       # restore defaults
+ankiniki note delete <noteId> [--force]
 ```
 
-**Configuration keys:**
+Note IDs are shown by `ankiniki note list <deck>`.
 
-| Key              | Default                 | Description                            |
-| ---------------- | ----------------------- | -------------------------------------- |
-| `ankiConnectUrl` | `http://localhost:8765` | AnkiConnect API endpoint               |
-| `serverUrl`      | `http://localhost:3001` | Ankiniki backend (used for import)     |
-| `defaultDeck`    | `Default`               | Deck used when none is specified       |
-| `defaultModel`   | `Basic`                 | Card model used when none is specified |
-| `debugMode`      | `false`                 | Verbose logging                        |
+```bash
+ankiniki note list "JavaScript"
+# → 1. Card ID: 1700000001
+#      Front: What is hoisting?
+
+ankiniki note delete 1700000001
+ankiniki note delete 1700000001 --force   # skip confirmation
+```
+
+---
+
+## `note generate` — AI-generate cards
+
+Generate flashcards from a file or piped content using the AI backend.
+
+```bash
+ankiniki note generate <file>   [options]
+ankiniki note generate --stdin  [options]
+```
 
 **Examples:**
 
 ```bash
-# Show current settings and connection status
-ankiniki config --show
+# Generate from a file (content type auto-detected from extension)
+ankiniki note generate README.md --deck "Docs"
+ankiniki note generate src/auth.ts --deck "Code" --lang typescript
 
-# Set default deck
-ankiniki config --set defaultDeck=JavaScript
+# Pipe content in
+cat CHANGELOG.md | ankiniki note generate --stdin --deck "Releases"
+git diff HEAD~1 | ankiniki note generate --stdin --content-type code --deck "Review"
 
-# Change backend URL
-ankiniki config --set serverUrl=http://localhost:3001
-
-# Interactive edit (opens prompts with live deck/model selection)
-ankiniki config --edit
-
-# Reset everything to defaults
-ankiniki config --reset
+# Non-interactive
+ankiniki note generate README.md --deck "Docs" --yes
 ```
 
-Config is saved at `~/.ankiniki.json`.
+| Option                  | Short | Description                                    |
+| ----------------------- | ----- | ---------------------------------------------- |
+| `--stdin`               |       | Read content from stdin                        |
+| `--deck <deck>`         | `-d`  | Target deck                                    |
+| `--content-type <type>` | `-t`  | `code` \| `markdown` \| `text` (auto-detected) |
+| `--difficulty <level>`  |       | `beginner` \| `intermediate` \| `advanced`     |
+| `--max-cards <n>`       | `-n`  | Max cards to generate (default: 5)             |
+| `--lang <language>`     |       | Programming language hint (for code files)     |
+| `--tags <tags>`         |       | Additional tags (comma-separated)              |
+| `--yes`                 | `-y`  | Add all generated cards without confirmation   |
 
 ---
 
-### `import` — Bulk import from file
+## `note import` — Bulk import from file
 
-Import multiple cards at once from CSV, JSON, or Markdown. Format is **auto-detected from the file extension**.
+Format is **auto-detected from the file extension** (`.csv`, `.json`, `.md`).
 
 ```bash
-ankiniki import <file> [options]
+ankiniki note import <file> [options]
 ```
 
-#### CSV import
+### CSV
 
 ```bash
-# Auto-detected from .csv extension
-ankiniki import cards.csv
-
-# Preview first (no cards created)
-ankiniki import cards.csv --preview
-
-# Override default deck and tags
-ankiniki import cards.csv --deck "JavaScript" --tags "imported,js"
+ankiniki note import cards.csv
+ankiniki note import cards.csv --preview          # dry run
+ankiniki note import cards.csv --deck "JavaScript" --tags "imported,js"
 ```
 
 **CSV format:**
@@ -240,36 +237,21 @@ ankiniki import cards.csv --deck "JavaScript" --tags "imported,js"
 ```csv
 Front,Back,Deck,Tags,Model
 "What is a closure?","A function capturing its enclosing scope","JavaScript","js,closures","Basic"
-"What is hoisting?","Moving declarations to the top","JavaScript","js","Basic"
 ```
 
-Minimal (deck/tags from CLI flags):
-
-```csv
-Front,Back
-"What is a closure?","A function capturing its enclosing scope"
-```
-
-Custom column names:
+Custom column mapping:
 
 ```bash
-ankiniki import cards.csv \
-  --mapping '{"front":"Question","back":"Answer","deck":"Subject","tags":"Topics"}'
+ankiniki note import cards.csv \
+  --mapping '{"front":"Question","back":"Answer","deck":"Subject"}'
 ```
 
----
-
-#### JSON import
+### JSON
 
 ```bash
-# Auto-detected from .json extension
-ankiniki import cards.json
-
-ankiniki import cards.json --preview
-ankiniki import cards.json --deck "Rust" --tags "rust"
+ankiniki note import cards.json
+ankiniki note import cards.json --deck "Rust"
 ```
-
-**JSON format (array):**
 
 ```json
 [
@@ -278,43 +260,16 @@ ankiniki import cards.json --deck "Rust" --tags "rust"
     "back": "Each value in Rust has one owner.",
     "deck": "Rust",
     "tags": ["rust", "memory"]
-  },
-  {
-    "front": "What is borrowing?",
-    "back": "Temporarily using a value without taking ownership.",
-    "deck": "Rust",
-    "tags": ["rust", "memory"]
   }
 ]
 ```
 
-**JSON format (object with defaults):**
-
-```json
-{
-  "deck_name": "Rust",
-  "default_tags": ["rust"],
-  "default_model": "Basic",
-  "cards": [
-    { "front": "What is ownership?", "back": "Each value has one owner." },
-    { "front": "What is borrowing?", "back": "Temporarily using without owning." }
-  ]
-}
-```
-
----
-
-#### Markdown import
+### Markdown
 
 ```bash
-# Auto-detected from .md extension
-ankiniki import cards.md
-
-ankiniki import cards.md --preview
-ankiniki import cards.md --deck "TypeScript"
+ankiniki note import cards.md
+ankiniki note import cards.md --preview
 ```
-
-**Markdown format:**
 
 ```markdown
 ---
@@ -322,191 +277,186 @@ deck: Programming::TypeScript
 tags: [typescript, types]
 ---
 
-## What is a type assertion?
-
-**Front:** What is a type assertion in TypeScript?
-**Back:** Telling the compiler to treat a value as a specific type using `as` or `<Type>`.
-
 ## What is a union type?
 
 **Front:** What is a union type?
 **Back:** A type that can be one of several types, written as `A | B`.
 ```
 
-- The frontmatter (`---` block) sets the default deck and tags
-- Each `##` section is one card
-- `**Front:**` and `**Back:**` are required in each section
-
----
-
-#### Common import options
+### Common options
 
 | Option               | Short | Description                             |
 | -------------------- | ----- | --------------------------------------- |
 | `--format <fmt>`     | `-f`  | Force format: `csv`, `json`, `markdown` |
-| `--deck <deck>`      |       | Default deck (overrides file content)   |
+| `--deck <deck>`      |       | Default deck                            |
 | `--model <model>`    |       | Card model (default: Basic)             |
 | `--tags <tags>`      |       | Extra tags (comma-separated)            |
 | `--preview`          | `-p`  | Dry run — show what would be imported   |
-| `--dry-run`          |       | Same as `--preview`                     |
 | `--delimiter <char>` | `-d`  | CSV delimiter (default: `,`)            |
 | `--mapping <json>`   |       | Custom CSV column mapping               |
 
 ---
 
-### `import mapping` — Show format examples
+## `note tag` — Bulk tag management
+
+Add or remove tags across all notes matching an AnkiConnect query.
 
 ```bash
-ankiniki import mapping
-```
-
----
-
-### `deck` — Manage decks
-
-```bash
-ankiniki deck list                   # list all decks with card counts
-ankiniki deck create <name>          # create a new deck
-ankiniki deck delete <name>          # delete deck (confirmation prompt)
-ankiniki deck delete <name> --force  # skip confirmation
+ankiniki note tag <query> --add <tags> [--remove <tags>] [--deck <name>] [--yes]
 ```
 
 **Examples:**
 
 ```bash
-# See all decks
+# Tag all notes in a deck
+ankiniki note tag "deck:Japanese" --add "n+1,active"
+
+# Rename a tag across all notes
+ankiniki note tag "tag:old-tag" --remove "old-tag" --add "new-tag" --yes
+
+# Tag this week's new notes
+ankiniki note tag "added:7" --add "this-week" --yes
+```
+
+| Option            | Short | Description                     |
+| ----------------- | ----- | ------------------------------- |
+| `--add <tags>`    |       | Comma-separated tags to add     |
+| `--remove <tags>` |       | Comma-separated tags to remove  |
+| `--deck <name>`   | `-d`  | Scope search to a specific deck |
+| `--yes`           | `-y`  | Skip confirmation prompt        |
+
+---
+
+## `deck` — Manage decks
+
+```bash
 ankiniki deck list
-
-# Create a nested deck
 ankiniki deck create "Programming::TypeScript"
-
-# Delete a deck and all its cards
 ankiniki deck delete "Old Deck"
+ankiniki deck delete "Old Deck" --force    # skip confirmation
 ```
 
-> `ankiniki deck delete` removes the deck **and all its cards**. A confirmation prompt is shown by default.
+> `deck delete` removes the deck **and all its cards**. A confirmation prompt is shown by default.
 
 ---
 
-### `delete` — Remove a card
+## `export` — Export a deck
 
 ```bash
-ankiniki delete <noteId>           # shows card preview + confirmation
-ankiniki delete <noteId> --force   # skip confirmation
+ankiniki export <deck> [output] [--format apkg|csv|json] [--query <query>] [--include-sched]
 ```
 
-Note IDs are shown by `ankiniki list --cards <deck>`.
-
-**Example:**
-
-```bash
-# Find the note ID first
-ankiniki list --cards "JavaScript"
-# → 1. Card ID: 1700000001
-#      Front: What is hoisting?
-
-# Delete it
-ankiniki delete 1700000001
-```
-
----
-
-### `export` — Export a deck as `.apkg`
-
-```bash
-ankiniki export <deck> [output]
-```
+| Format | Description                                        |
+| ------ | -------------------------------------------------- |
+| `apkg` | Anki package — import directly into Anki (default) |
+| `csv`  | Spreadsheet-friendly, all fields + tags            |
+| `json` | Machine-readable array of note objects             |
 
 **Examples:**
 
 ```bash
-# Export to current directory (saves as JavaScript.apkg)
-ankiniki export "JavaScript"
-
-# Export to a specific path
-ankiniki export "Programming::Rust" ~/backups/rust.apkg
-
-# Include scheduling and review history
-ankiniki export "JavaScript" --include-sched
+ankiniki export "JavaScript"                             # → JavaScript.apkg
+ankiniki export "JavaScript" --format csv               # → JavaScript.csv
+ankiniki export "JavaScript" --format json              # → JavaScript.json
+ankiniki export "JavaScript" notes.apkg --include-sched
+ankiniki export "JavaScript" --format csv --query "tag:hard"
 ```
-
-**Options:**
-
-| Option            | Description                                     |
-| ----------------- | ----------------------------------------------- |
-| `--include-sched` | Include Anki scheduling and review history data |
-
-The `.apkg` file can be imported directly into any Anki installation via File → Import.
 
 ---
 
-## Common Workflows
-
-### Engineer workflow: capture while coding
+## `stats` — Review statistics
 
 ```bash
-# Just learned something in Rust — add it immediately
-ankiniki add "Rust" \
-  "What does \`Option::unwrap_or_else\` do?" \
-  "Returns the value or calls a closure to compute a fallback"  \
-  --tags "rust,option,error-handling"
+ankiniki stats                     # full dashboard
+ankiniki stats --brief             # one-line summary (e.g. for status bars)
+ankiniki stats --deck "JavaScript" # scope to one deck
+```
 
-# Check it was added
-ankiniki list --cards "Rust"
+---
+
+## `sync` — AnkiWeb sync
+
+```bash
+ankiniki sync
+```
+
+Triggers the same sync as Anki's built-in "Sync" button. Requires an AnkiWeb account configured in Anki.
+
+---
+
+## `config` — Settings
+
+```bash
+ankiniki config --show
+ankiniki config --set defaultDeck=JavaScript
+ankiniki config --set serverUrl=http://localhost:3001
+ankiniki config --edit
+ankiniki config --reset
+```
+
+| Key              | Default                 | Description                              |
+| ---------------- | ----------------------- | ---------------------------------------- |
+| `ankiConnectUrl` | `http://localhost:8765` | AnkiConnect API endpoint                 |
+| `serverUrl`      | `http://localhost:3001` | Ankiniki backend (for import + generate) |
+| `defaultDeck`    | `Default`               | Deck used when none is specified         |
+| `defaultModel`   | `Basic`                 | Card model used when none is specified   |
+| `debugMode`      | `false`                 | Verbose logging                          |
+
+Config is saved at `~/.ankiniki.json`.
+
+---
+
+## Common workflows
+
+### Capture while coding
+
+```bash
+ankiniki note add "Rust" \
+  "What does \`Option::unwrap_or_else\` do?" \
+  "Returns the value or calls a closure to compute a fallback" \
+  --tags "rust,option"
 ```
 
 ### Batch import from study notes
 
 ```bash
-# Write cards in Markdown while reading docs, then import all at once
-ankiniki import study-notes.md --preview   # check first
-ankiniki import study-notes.md
+ankiniki note import study-notes.md --preview
+ankiniki note import study-notes.md
 ```
 
-### Daily review in terminal
+### AI-generate cards from a PR diff
 
 ```bash
-# 10 random cards from your main deck
+git diff main | ankiniki note generate --stdin --content-type code --deck "Review" --yes
+```
+
+### Daily review
+
+```bash
 ankiniki study "Programming" --count 10 --random
 ```
 
-### Back up or share a deck
+### Back up a deck
 
 ```bash
-# Export a deck to share with a colleague or move to another machine
-ankiniki export "Programming::Rust" rust-deck.apkg
-
-# Include your review history (progress, scheduling)
 ankiniki export "Programming::Rust" rust-deck.apkg --include-sched
-# Import on the other machine: Anki → File → Import → select rust-deck.apkg
 ```
 
-### Clean up old cards
+### Rename a tag across a deck
 
 ```bash
-# List cards to find the one to remove
-ankiniki list --cards "JavaScript" --limit 50
-
-# Delete by note ID (shown in the list output)
-ankiniki delete 1700000001
-```
-
-### Sync config on a new machine
-
-```bash
-ankiniki config --edit   # set ankiConnectUrl, serverUrl, defaultDeck
-ankiniki config --show   # verify connection is green
+ankiniki note tag "deck:Japanese" --remove "todo" --add "done" --yes
 ```
 
 ---
 
 ## Troubleshooting
 
-| Problem                    | Fix                                                                           |
-| -------------------------- | ----------------------------------------------------------------------------- |
-| `Cannot connect to Anki`   | Make sure Anki desktop is open and AnkiConnect is installed                   |
-| `Deck does not exist`      | Create the deck in Anki first, or check the name spelling                     |
-| `Import failed: API Error` | Check backend server is running (`npm run dev --workspace=@ankiniki/backend`) |
-| `Model does not exist`     | Use `ankiniki list` to see model names, or use `Basic`                        |
+| Problem                    | Fix                                                                                    |
+| -------------------------- | -------------------------------------------------------------------------------------- |
+| `Cannot connect to Anki`   | Make sure Anki desktop is open and AnkiConnect is installed                            |
+| `Deck does not exist`      | Create the deck with `ankiniki deck create "<name>"` or check spelling                 |
+| `Import failed: API Error` | Check backend server is running (`npm run dev --workspace=@ankiniki/backend`)          |
+| `Model does not exist`     | Use `ankiniki deck list` to see decks, then check model names in Anki desktop settings |
 
 AnkiConnect status: open `http://localhost:8765` in a browser — it should return a version number.


### PR DESCRIPTION
## Summary

- New `note` subcommand group containing: `add`, `list`, `edit`, `delete`, `generate`, `import`, `tag`
- `note list <deck>` replaces `list --cards <deck>` (positional arg, cleaner)
- `list --decks` removed — `deck list` is the single place for that
- `index.ts` reduced to: `note` group + `deck` group + 7 standalone utilities
- No new logic, pure reorganisation

## Before → After

```
# Before
ankiniki add / list / edit / delete / generate / import / tag   (all top-level, mixed with deck ops)
ankiniki list                  → lists decks
ankiniki list --cards "Deck"   → lists cards
ankiniki list --decks          → also lists decks

# After
ankiniki note add / list / edit / delete / generate / import / tag
ankiniki note list "Deck"      → lists cards (positional, no flag needed)
ankiniki deck list             → single home for deck listing
```

## Files changed

| File | Change |
|------|--------|
| `commands/note.ts` | New — container command wiring all note ops |
| `commands/list.ts` | Stripped to cards-only, `<deck>` positional arg |
| `index.ts` | Replaced 13 individual adds with 2 groups + 7 utilities |
| `__tests__/list.test.ts` | Updated for new positional API, removed `--decks` tests |
| `apps/cli/README.md` | Full rewrite to new structure |
| `docs/user-guides/cli/README.md` | Full rewrite (EN) |
| `docs/ja/user-guides/cli/README.md` | Full rewrite (JA) |

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)