### PR TITLE
#73 Add --field flag to note edit for non-interactive updates

### DIFF
--- a/apps/cli/src/__tests__/edit.test.ts
+++ b/apps/cli/src/__tests__/edit.test.ts
@@ -196,3 +196,81 @@ describe('edit command', () => {
     exitSpy.mockRestore();
   });
 });
+
+describe('edit command — non-interactive (--field)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockClient.ping.mockResolvedValue(true);
+    mockClient.findNotes.mockResolvedValue([101]);
+    mockClient.notesInfo.mockResolvedValue([NOTE_1]);
+    mockClient.updateNoteFields.mockResolvedValue(undefined);
+    consoleSpy.mockImplementation(() => {});
+  });
+
+  it('updates fields without prompts when --field is provided', async () => {
+    await run([
+      'TypeScript',
+      '--field',
+      'Front=Updated front',
+      '--field',
+      'Back=Updated back',
+    ]);
+
+    expect(mockInquirerPrompt).not.toHaveBeenCalled();
+    expect(mockClient.updateNoteFields).toHaveBeenCalledWith(101, {
+      Front: 'Updated front',
+      Back: 'Updated back',
+    });
+  });
+
+  it('treats a bare integer query as nid: search', async () => {
+    await run(['1234567890', '--field', 'Back=new value']);
+
+    expect(mockClient.findNotes).toHaveBeenCalledWith('nid:1234567890');
+  });
+
+  it('uses deck-scoped query for non-numeric queries', async () => {
+    await run(['しかし', '--deck', 'Japanese', '--field', 'Back=new']);
+
+    expect(mockClient.findNotes).toHaveBeenCalledWith('deck:"Japanese" しかし');
+  });
+
+  it('exits with error when --field query matches multiple notes', async () => {
+    mockClient.findNotes.mockResolvedValue([101, 102]);
+    mockClient.notesInfo.mockResolvedValue([NOTE_1, NOTE_2]);
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit: 1');
+    });
+
+    await expect(run(['type', '--field', 'Back=x'])).rejects.toThrow(
+      'process.exit: 1'
+    );
+    expect(mockClient.updateNoteFields).not.toHaveBeenCalled();
+    exitSpy.mockRestore();
+  });
+
+  it('exits with error when --field specifies an unknown field name', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit: 1');
+    });
+
+    await expect(
+      run(['TypeScript', '--field', 'NonExistent=x'])
+    ).rejects.toThrow('process.exit: 1');
+    expect(mockClient.updateNoteFields).not.toHaveBeenCalled();
+    exitSpy.mockRestore();
+  });
+
+  it('exits when no notes found in non-interactive mode', async () => {
+    mockClient.findNotes.mockResolvedValue([]);
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit: 1');
+    });
+
+    await expect(run(['missing', '--field', 'Back=x'])).rejects.toThrow(
+      'process.exit: 1'
+    );
+    expect(mockClient.updateNoteFields).not.toHaveBeenCalled();
+    exitSpy.mockRestore();
+  });
+});

--- a/apps/cli/src/commands/edit.ts
+++ b/apps/cli/src/commands/edit.ts
@@ -24,6 +24,23 @@ function sortedFields(
     .map(([name, { value }]) => ({ name, value }));
 }
 
+function collectField(
+  value: string,
+  previous: Record<string, string>
+): Record<string, string> {
+  const eqIdx = value.indexOf('=');
+  if (eqIdx === -1) {
+    throw new Error(`--field must be "FieldName=value", got: ${value}`);
+  }
+  return { ...previous, [value.slice(0, eqIdx)]: value.slice(eqIdx + 1) };
+}
+
+interface EditOptions {
+  deck?: string;
+  limit: string;
+  field: Record<string, string>;
+}
+
 export function createEditCommand(): Command {
   const command = new Command('edit');
 
@@ -31,7 +48,7 @@ export function createEditCommand(): Command {
     .description('Search for a card and edit it in your $EDITOR')
     .argument(
       '<query>',
-      'AnkiConnect search query (e.g. "TypeScript" or tag:js)'
+      'AnkiConnect search query or note ID (e.g. "TypeScript", tag:js, 1234567890)'
     )
     .option('-d, --deck <name>', 'Scope search to a specific deck')
     .option(
@@ -39,21 +56,32 @@ export function createEditCommand(): Command {
       `Max results to show in picker (default ${DEFAULT_LIMIT})`,
       String(DEFAULT_LIMIT)
     )
-    .action(
-      async (query: string, options: { deck?: string; limit: string }) => {
-        const client = new AnkiClient();
+    .option(
+      '--field <assignment>',
+      'Non-interactive: set FieldName=value (repeatable, e.g. --field Front="q" --field Back="a")',
+      collectField,
+      {} as Record<string, string>
+    )
+    .action(async (query: string, options: EditOptions) => {
+      const client = new AnkiClient();
 
-        const connSpinner = ora(ANKI_MESSAGES.CONNECTING).start();
-        if (!(await client.ping())) {
-          connSpinner.fail(ANKI_MESSAGES.CANNOT_CONNECT);
-          process.exit(1);
-        }
-        connSpinner.succeed(ANKI_MESSAGES.CONNECTED);
+      const connSpinner = ora(ANKI_MESSAGES.CONNECTING).start();
+      if (!(await client.ping())) {
+        connSpinner.fail(ANKI_MESSAGES.CANNOT_CONNECT);
+        process.exit(1);
+      }
+      connSpinner.succeed(ANKI_MESSAGES.CONNECTED);
 
-        // ── 1. Search ───────────────────────────────────────────────────────
-        const fullQuery = options.deck
-          ? `deck:"${options.deck}" ${query}`
-          : query;
+      const hasFieldUpdates = Object.keys(options.field).length > 0;
+
+      // ── Non-interactive path ────────────────────────────────────────────────
+      if (hasFieldUpdates) {
+        // A bare integer is almost certainly a note ID; convert to nid: search.
+        const fullQuery = /^\d+$/.test(query)
+          ? `nid:${query}`
+          : options.deck
+            ? `deck:"${options.deck}" ${query}`
+            : query;
 
         const searchSpinner = ora('Searching…').start();
         let noteIds: number[];
@@ -68,105 +96,170 @@ export function createEditCommand(): Command {
           searchSpinner.fail(chalk.yellow('No notes found for that query.'));
           process.exit(1);
         }
+        if (noteIds.length > 1) {
+          searchSpinner.fail(
+            chalk.yellow(
+              `Query matched ${noteIds.length} notes. Narrow your query or use a note ID (nid:<id>) to target a single note.`
+            )
+          );
+          process.exit(1);
+        }
+        searchSpinner.succeed(`Found note ${noteIds[0]}`);
 
-        const limit = Math.max(1, parseInt(options.limit, 10) || DEFAULT_LIMIT);
-        const sliced = noteIds.slice(0, limit);
-        searchSpinner.succeed(
-          `Found ${noteIds.length} note${noteIds.length !== 1 ? 's' : ''}${
-            noteIds.length > limit ? ` — showing first ${limit}` : ''
-          }`
-        );
-
-        // ── 2. Fetch note details ───────────────────────────────────────────
-        const infoSpinner = ora('Loading notes…').start();
-        let notes: NoteInfo[];
+        const infoSpinner = ora('Loading note…').start();
+        let note: NoteInfo;
         try {
-          notes = await client.notesInfo(sliced);
+          [note] = await client.notesInfo([noteIds[0]]);
         } catch (error: any) {
-          infoSpinner.fail(chalk.red(`Failed to load notes: ${error.message}`));
+          infoSpinner.fail(chalk.red(`Failed to load note: ${error.message}`));
           process.exit(1);
         }
         infoSpinner.stop();
 
-        // ── 3. Pick a note ──────────────────────────────────────────────────
-        let selectedNote: NoteInfo;
-
-        if (notes.length === 1) {
-          selectedNote = notes[0];
-          const fields = sortedFields(selectedNote.fields);
-          console.log(
-            chalk.gray(`\nFound 1 note: `) +
-              chalk.cyan(
-                clip(fields[0]?.value ?? String(selectedNote.noteId), 72)
-              )
-          );
-        } else {
-          const { noteId } = await inquirer.prompt<{ noteId: number }>([
-            {
-              type: 'list',
-              name: 'noteId',
-              message: 'Select a note to edit:',
-              pageSize: 15,
-              choices: notes.map(n => {
-                const fields = sortedFields(n.fields);
-                const front = fields[0]?.value ?? String(n.noteId);
-                const back = fields[1]?.value ?? '';
-                return {
-                  name:
-                    chalk.cyan(clip(front, 55)) +
-                    chalk.gray('  →  ') +
-                    chalk.gray(clip(back, 40)),
-                  value: n.noteId,
-                };
-              }),
-            },
-          ]);
-          selectedNote = notes.find(n => n.noteId === noteId)!;
-        }
-
-        // ── 4. Edit fields ──────────────────────────────────────────────────
-        const fields = sortedFields(selectedNote.fields);
-        console.log(
-          chalk.bold(`\nEditing note `) +
-            chalk.gray(String(selectedNote.noteId)) +
-            chalk.bold(` (${selectedNote.modelName})`)
+        const validFieldNames = Object.keys(note.fields);
+        const invalid = Object.keys(options.field).filter(
+          f => !validFieldNames.includes(f)
         );
-
-        const edited: Record<string, string> = {};
-        for (const field of fields) {
-          const { value } = await inquirer.prompt<{ value: string }>([
-            {
-              type: 'editor',
-              name: 'value',
-              message: `${chalk.bold(field.name)}:`,
-              default: field.value,
-            },
-          ]);
-          edited[field.name] = value.trim();
+        if (invalid.length > 0) {
+          console.error(
+            chalk.red(
+              `Unknown field(s): ${invalid.join(', ')}. Available: ${validFieldNames.join(', ')}`
+            )
+          );
+          process.exit(1);
         }
 
-        // Confirm if nothing changed
-        const changed = fields.filter(f => edited[f.name] !== f.value);
-        if (changed.length === 0) {
-          console.log(chalk.gray('\nNo changes made.'));
-          return;
-        }
-
-        // ── 5. Save ─────────────────────────────────────────────────────────
         const saveSpinner = ora('Saving…').start();
         try {
-          await client.updateNoteFields(selectedNote.noteId, edited);
+          await client.updateNoteFields(note.noteId, options.field);
           saveSpinner.succeed(
             chalk.green(
-              `Note ${selectedNote.noteId} updated (${changed.length} field${changed.length !== 1 ? 's' : ''} changed)`
+              `Note ${note.noteId} updated (${Object.keys(options.field).length} field${Object.keys(options.field).length !== 1 ? 's' : ''} changed)`
             )
           );
         } catch (error: any) {
           saveSpinner.fail(chalk.red(`Failed to save: ${error.message}`));
           process.exit(1);
         }
+        return;
       }
-    );
+
+      // ── Interactive path ────────────────────────────────────────────────────
+      const fullQuery = options.deck
+        ? `deck:"${options.deck}" ${query}`
+        : query;
+
+      const searchSpinner = ora('Searching…').start();
+      let noteIds: number[];
+      try {
+        noteIds = await client.findNotes(fullQuery);
+      } catch (error: any) {
+        searchSpinner.fail(chalk.red(`Search failed: ${error.message}`));
+        process.exit(1);
+      }
+
+      if (noteIds.length === 0) {
+        searchSpinner.fail(chalk.yellow('No notes found for that query.'));
+        process.exit(1);
+      }
+
+      const limit = Math.max(1, parseInt(options.limit, 10) || DEFAULT_LIMIT);
+      const sliced = noteIds.slice(0, limit);
+      searchSpinner.succeed(
+        `Found ${noteIds.length} note${noteIds.length !== 1 ? 's' : ''}${
+          noteIds.length > limit ? ` — showing first ${limit}` : ''
+        }`
+      );
+
+      // ── 2. Fetch note details ───────────────────────────────────────────
+      const infoSpinner = ora('Loading notes…').start();
+      let notes: NoteInfo[];
+      try {
+        notes = await client.notesInfo(sliced);
+      } catch (error: any) {
+        infoSpinner.fail(chalk.red(`Failed to load notes: ${error.message}`));
+        process.exit(1);
+      }
+      infoSpinner.stop();
+
+      // ── 3. Pick a note ──────────────────────────────────────────────────
+      let selectedNote: NoteInfo;
+
+      if (notes.length === 1) {
+        selectedNote = notes[0];
+        const fields = sortedFields(selectedNote.fields);
+        console.log(
+          chalk.gray(`\nFound 1 note: `) +
+            chalk.cyan(
+              clip(fields[0]?.value ?? String(selectedNote.noteId), 72)
+            )
+        );
+      } else {
+        const { noteId } = await inquirer.prompt<{ noteId: number }>([
+          {
+            type: 'list',
+            name: 'noteId',
+            message: 'Select a note to edit:',
+            pageSize: 15,
+            choices: notes.map(n => {
+              const fields = sortedFields(n.fields);
+              const front = fields[0]?.value ?? String(n.noteId);
+              const back = fields[1]?.value ?? '';
+              return {
+                name:
+                  chalk.cyan(clip(front, 55)) +
+                  chalk.gray('  →  ') +
+                  chalk.gray(clip(back, 40)),
+                value: n.noteId,
+              };
+            }),
+          },
+        ]);
+        selectedNote = notes.find(n => n.noteId === noteId)!;
+      }
+
+      // ── 4. Edit fields ──────────────────────────────────────────────────
+      const fields = sortedFields(selectedNote.fields);
+      console.log(
+        chalk.bold(`\nEditing note `) +
+          chalk.gray(String(selectedNote.noteId)) +
+          chalk.bold(` (${selectedNote.modelName})`)
+      );
+
+      const edited: Record<string, string> = {};
+      for (const field of fields) {
+        const { value } = await inquirer.prompt<{ value: string }>([
+          {
+            type: 'editor',
+            name: 'value',
+            message: `${chalk.bold(field.name)}:`,
+            default: field.value,
+          },
+        ]);
+        edited[field.name] = value.trim();
+      }
+
+      // Confirm if nothing changed
+      const changed = fields.filter(f => edited[f.name] !== f.value);
+      if (changed.length === 0) {
+        console.log(chalk.gray('\nNo changes made.'));
+        return;
+      }
+
+      // ── 5. Save ─────────────────────────────────────────────────────────
+      const saveSpinner = ora('Saving…').start();
+      try {
+        await client.updateNoteFields(selectedNote.noteId, edited);
+        saveSpinner.succeed(
+          chalk.green(
+            `Note ${selectedNote.noteId} updated (${changed.length} field${changed.length !== 1 ? 's' : ''} changed)`
+          )
+        );
+      } catch (error: any) {
+        saveSpinner.fail(chalk.red(`Failed to save: ${error.message}`));
+        process.exit(1);
+      }
+    });
 
   return command;
 }


### PR DESCRIPTION
## Summary

Adds a `--field FieldName=value` flag to `ankiniki note edit` so field updates can be scripted without `$EDITOR` prompts.

## Changes

### `apps/cli/src/commands/edit.ts`

- New `--field <assignment>` option (repeatable via Commander collector)
- Non-interactive path: search → validate single result → validate field names → save
- Bare integer query auto-converts to `nid:<id>` so `ankiniki note edit "$noteId" --field ...` works naturally
- Multiple-match guard: exits with a clear error if query hits >1 note
- Interactive path unchanged

### `apps/cli/src/__tests__/edit.test.ts`

- 6 new tests covering the `--field` path (no-prompt update, nid: auto-conversion, deck scope, multi-match guard, unknown field, empty result)

## Usage

```bash
# Update by note ID (auto-converts to nid: search)
ankiniki note edit 1234567890 --field Back="new back text"

# Update multiple fields
ankiniki note edit "しかし" --deck "Japanese" --field Front="updated" --field Back="updated"

# Scripted bulk edit
ankiniki note list "Japanese" --json | jq -r '.[].id' | while read id; do
  ankiniki note edit "$id" --field Back="$(build_back $id)"
done
```

## Test Results

- ✅ All 91 tests passing (11 files)
- ✅ Build verified successful

Closes #73

🤖 Generated with [Claude Code](https://claude.ai/code)