### PR TITLE
#86 Desktop — wire Sync menu item to AnkiWeb sync

### DIFF
--- a/apps/desktop/src/renderer/App.tsx
+++ b/apps/desktop/src/renderer/App.tsx
@@ -1,46 +1,68 @@
-import React, { useState, useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Layout } from './components/Layout';
 import { DeckList } from './components/DeckList';
 import { CardEditor } from './components/CardEditor';
 import { StudyView } from './components/StudyView';
 import { Settings } from './components/Settings';
 
+const BACKEND_URL = 'http://localhost:3001';
+
 type View = 'decks' | 'editor' | 'study' | 'settings';
+type ToastType = 'info' | 'success' | 'error';
+
+interface Toast {
+  id: number;
+  type: ToastType;
+  message: string;
+}
+
+let toastSeq = 0;
 
 function App() {
   const [currentView, setCurrentView] = useState<View>('decks');
   const [selectedDeck, setSelectedDeck] = useState<string | null>(null);
+  const [toasts, setToasts] = useState<Toast[]>([]);
+
+  const addToast = (type: ToastType, message: string) => {
+    const id = ++toastSeq;
+    setToasts(prev => [...prev, { id, type, message }]);
+    setTimeout(
+      () => setToasts(prev => prev.filter(t => t.id !== id)),
+      type === 'error' ? 5000 : 3000
+    );
+  };
+
+  const triggerSync = async () => {
+    addToast('info', 'Syncing with AnkiWeb…');
+    try {
+      const res = await fetch(`${BACKEND_URL}/api/sync`, { method: 'POST' });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.message ?? `Server error: ${res.status}`);
+      }
+      addToast('success', 'Sync complete');
+    } catch (err: any) {
+      addToast('error', `Sync failed: ${err.message}`);
+    }
+  };
 
   useEffect(() => {
-    // Set up menu listeners
-    if (window.electronAPI) {
-      window.electronAPI.onMenuNewCard(() => {
-        setCurrentView('editor');
-      });
-
-      window.electronAPI.onMenuReview(() => {
-        setCurrentView('study');
-      });
-
-      window.electronAPI.onMenuSync(() => {
-        // TODO: Implement sync functionality
-        console.log('Sync requested');
-      });
-
-      window.electronAPI.onMenuAbout(() => {
-        // TODO: Show about dialog
-        console.log('About requested');
-      });
+    if (!window.electronAPI) {
+      return;
     }
 
-    // Cleanup
+    window.electronAPI.onMenuNewCard(() => setCurrentView('editor'));
+    window.electronAPI.onMenuReview(() => setCurrentView('study'));
+    window.electronAPI.onMenuSync(() => triggerSync());
+    window.electronAPI.onMenuAbout(() =>
+      addToast('info', 'Ankiniki v0.1.0 — Anki companion tool for engineers')
+    );
+
     return () => {
-      if (window.electronAPI) {
-        window.electronAPI.removeAllListeners('menu-new-card');
-        window.electronAPI.removeAllListeners('menu-review');
-        window.electronAPI.removeAllListeners('menu-sync');
-        window.electronAPI.removeAllListeners('menu-about');
-      }
+      window.electronAPI?.removeAllListeners('menu-new-card');
+      window.electronAPI?.removeAllListeners('menu-review');
+      window.electronAPI?.removeAllListeners('menu-sync');
+      window.electronAPI?.removeAllListeners('menu-about');
     };
   }, []);
 
@@ -60,13 +82,56 @@ function App() {
   };
 
   return (
-    <Layout
-      currentView={currentView}
-      onViewChange={setCurrentView}
-      selectedDeck={selectedDeck}
-    >
-      {renderCurrentView()}
-    </Layout>
+    <>
+      <Layout
+        currentView={currentView}
+        onViewChange={setCurrentView}
+        selectedDeck={selectedDeck}
+      >
+        {renderCurrentView()}
+      </Layout>
+
+      {toasts.length > 0 && (
+        <div className='toast-container'>
+          {toasts.map(t => (
+            <div key={t.id} className={`toast toast-${t.type}`}>
+              {t.message}
+            </div>
+          ))}
+        </div>
+      )}
+
+      <style>{`
+        .toast-container {
+          position: fixed;
+          bottom: 1.5rem;
+          right: 1.5rem;
+          display: flex;
+          flex-direction: column;
+          gap: 0.5rem;
+          z-index: 9999;
+        }
+
+        .toast {
+          padding: 0.75rem 1.25rem;
+          border-radius: 8px;
+          font-size: 0.9rem;
+          font-weight: 500;
+          box-shadow: 0 4px 12px rgba(0,0,0,0.15);
+          animation: slide-in 0.2s ease;
+          max-width: 320px;
+        }
+
+        .toast-info    { background: #3b82f6; color: white; }
+        .toast-success { background: #22c55e; color: white; }
+        .toast-error   { background: #ef4444; color: white; }
+
+        @keyframes slide-in {
+          from { transform: translateX(120%); opacity: 0; }
+          to   { transform: translateX(0);    opacity: 1; }
+        }
+      `}</style>
+    </>
   );
 }
 

--- a/packages/backend/src/routes/index.ts
+++ b/packages/backend/src/routes/index.ts
@@ -6,6 +6,7 @@ import mlRoutes from './ml';
 import importRoutes from './import';
 import exportRoutes from './export';
 import studyRoutes from './study';
+import syncRoutes from './sync';
 
 const router = Router();
 
@@ -19,5 +20,6 @@ router.use('/api/ml', mlRoutes);
 router.use('/api/import', importRoutes);
 router.use('/api/export', exportRoutes);
 router.use('/api/study', studyRoutes);
+router.use('/api/sync', syncRoutes);
 
 export default router;

--- a/packages/backend/src/routes/sync.ts
+++ b/packages/backend/src/routes/sync.ts
@@ -1,0 +1,17 @@
+import { Router, Response } from 'express';
+import { ApiResponse } from '@ankiniki/shared';
+import { ankiConnect } from '../services/ankiConnect';
+import { ok } from '../utils/response';
+import { asyncHandler } from '../utils/asyncHandler';
+
+const router = Router();
+
+router.post(
+  '/',
+  asyncHandler(async (_req, res: Response<ApiResponse>) => {
+    await ankiConnect.sync();
+    res.json(ok(null, 'Sync complete'));
+  })
+);
+
+export default router;


### PR DESCRIPTION
## Summary

Wires the "Sync with Anki" menu item (Cmd/Ctrl+S) to a real AnkiWeb sync call, with visible feedback via a toast notification system.

## Changes

### `packages/backend/src/routes/sync.ts` (new)
- `POST /api/sync` — calls `ankiConnect.sync()` and returns `ok`

### `packages/backend/src/routes/index.ts`
- Mount sync route at `/api/sync`

### `apps/desktop/src/renderer/App.tsx`
- `triggerSync()`: fetches `POST /api/sync`, shows info → success/error toasts
- `onMenuSync` handler replaced with `triggerSync()`
- Added lightweight toast system (info/success/error, auto-dismiss after 3–5 s, slide-in animation)
- `onMenuAbout` wired to an info toast instead of `console.log`

## Test Results

- ✅ Backend build passes
- ✅ Desktop build passes
- ✅ All CLI tests passing (91/91)

Closes #86

🤖 Generated with [Claude Code](https://claude.ai/code)