### PR TITLE
#85 Convert \n to <br> in note add field values

### DIFF
--- a/apps/cli/src/__tests__/add.test.ts
+++ b/apps/cli/src/__tests__/add.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createAddCommand } from '../commands/add';
+
+// ── Client mock ────────────────────────────────────────────────────────────
+
+const mockClient = {
+  ping: vi.fn().mockResolvedValue(true),
+  getDeckNames: vi.fn().mockResolvedValue(['Default']),
+  modelNames: vi.fn().mockResolvedValue(['Basic']),
+  modelFieldNames: vi.fn().mockResolvedValue(['Front', 'Back']),
+  addNote: vi.fn().mockResolvedValue(12345),
+};
+
+vi.mock('../anki-client', () => ({
+  AnkiClient: class {
+    constructor() {
+      return mockClient;
+    }
+  },
+}));
+
+vi.mock('../config', () => ({
+  loadConfig: () => ({ defaultDeck: 'Default', defaultModel: 'Basic' }),
+}));
+
+vi.mock('ora', () => ({
+  default: vi.fn(() => ({
+    start: vi.fn().mockReturnThis(),
+    succeed: vi.fn().mockReturnThis(),
+    fail: vi.fn().mockReturnThis(),
+    stop: vi.fn().mockReturnThis(),
+  })),
+}));
+
+const mockInquirerPrompt = vi.fn();
+vi.mock('inquirer', () => ({
+  default: {
+    prompt: (...args: unknown[]) => mockInquirerPrompt(...args),
+  },
+}));
+
+vi.spyOn(console, 'log').mockImplementation(() => {});
+vi.spyOn(console, 'error').mockImplementation(() => {});
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+async function run(args: string[]) {
+  const cmd = createAddCommand();
+  await cmd.parseAsync(args, { from: 'user' });
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+describe('add command', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockClient.ping.mockResolvedValue(true);
+    mockClient.getDeckNames.mockResolvedValue(['Default']);
+    mockClient.modelNames.mockResolvedValue(['Basic']);
+    mockClient.modelFieldNames.mockResolvedValue(['Front', 'Back']);
+    mockClient.addNote.mockResolvedValue(12345);
+  });
+
+  it('converts \\n to <br> in front and back fields', async () => {
+    await run([
+      'Default',
+      'line1\nline2',
+      'answer1\nanswer2',
+      '--model',
+      'Basic',
+    ]);
+
+    expect(mockClient.addNote).toHaveBeenCalledWith(
+      'Default',
+      'Basic',
+      { Front: 'line1<br>line2', Back: 'answer1<br>answer2' },
+      []
+    );
+  });
+
+  it('passes plain text unchanged when no newlines', async () => {
+    await run([
+      'Default',
+      'What is TypeScript?',
+      'A typed superset of JS',
+      '--model',
+      'Basic',
+    ]);
+
+    expect(mockClient.addNote).toHaveBeenCalledWith(
+      'Default',
+      'Basic',
+      { Front: 'What is TypeScript?', Back: 'A typed superset of JS' },
+      []
+    );
+  });
+
+  it('converts multiple newlines in a single field', async () => {
+    await run(['Default', 'a\nb\nc', 'answer', '--model', 'Basic']);
+
+    const [, , fields] = mockClient.addNote.mock.calls[0];
+    expect(fields.Front).toBe('a<br>b<br>c');
+  });
+
+  it('uses model field names from AnkiConnect', async () => {
+    mockClient.modelFieldNames.mockResolvedValue(['Question', 'Answer']);
+
+    await run(['Default', 'q\ntext', 'a\ntext', '--model', 'Basic']);
+
+    const [, , fields] = mockClient.addNote.mock.calls[0];
+    expect(fields).toEqual({ Question: 'q<br>text', Answer: 'a<br>text' });
+  });
+
+  it('falls back to Front/Back when model has fewer than 2 fields', async () => {
+    mockClient.modelFieldNames.mockResolvedValue(['OnlyField']);
+
+    await run(['Default', 'front\nvalue', 'back\nvalue', '--model', 'Basic']);
+
+    const [, , fields] = mockClient.addNote.mock.calls[0];
+    expect(fields).toEqual({ Front: 'front<br>value', Back: 'back<br>value' });
+  });
+});

--- a/apps/cli/src/commands/add.ts
+++ b/apps/cli/src/commands/add.ts
@@ -108,11 +108,11 @@ export function createAddCommand(): Command {
         // Map to AnkiConnect fields format
         const fields: Record<string, string> = {};
         if (fieldNames.length >= 2) {
-          fields[fieldNames[0]] = cardData.front;
-          fields[fieldNames[1]] = cardData.back;
+          fields[fieldNames[0]] = cardData.front.replace(/\n/g, '<br>');
+          fields[fieldNames[1]] = cardData.back.replace(/\n/g, '<br>');
         } else {
-          fields.Front = cardData.front;
-          fields.Back = cardData.back;
+          fields.Front = cardData.front.replace(/\n/g, '<br>');
+          fields.Back = cardData.back.replace(/\n/g, '<br>');
         }
 
         // Add the note


### PR DESCRIPTION
## Summary
- Anki renders card fields as HTML; raw `\n` characters display as whitespace in reviews
- Added `.replace(/\n/g, '<br>')` to both field assignments in `add.ts` (both the model-field-names path and the fallback `Front`/`Back` path)
- Added `apps/cli/src/__tests__/add.test.ts` with 5 tests covering the conversion, no-op on plain text, multiple newlines, custom field names, and the single-field fallback

Closes #85

## Test plan
- [x] `\n → <br>` conversion applied to front and back before `addNote` call
- [x] Plain text passes through unchanged
- [x] Multiple consecutive newlines each converted
- [x] Custom model field names also get the conversion
- [x] Fallback `Front`/`Back` branch also converts
- [x] All 96 CLI tests pass

🤖 Generated with [Claude Code](https://claude.ai/claude-code)