### PR TITLE
#85 Convert \n to <br> in import field values

### DIFF
--- a/packages/shared/src/__tests__/import-parsers.test.ts
+++ b/packages/shared/src/__tests__/import-parsers.test.ts
@@ -271,13 +271,23 @@ describe('mapCardFields', () => {
   });
 
   it('maps Cloze model to Text field', () => {
-    expect(mapCardFields('Q', 'A', 'Cloze')).toEqual({ Text: 'Q\n\nA' });
+    expect(mapCardFields('Q', 'A', 'Cloze')).toEqual({ Text: 'Q<br><br>A' });
   });
 
   it('falls back to Front/Back for unknown models', () => {
     expect(mapCardFields('Q', 'A', 'BasicAndReversed')).toEqual({
       Front: 'Q',
       Back: 'A',
+    });
+  });
+
+  it('converts \\n to <br> in all model types', () => {
+    expect(mapCardFields('line1\nline2', 'ans\nhere', 'Basic')).toEqual({
+      Front: 'line1<br>line2',
+      Back: 'ans<br>here',
+    });
+    expect(mapCardFields('front\ntext', 'back\ntext', 'Cloze')).toEqual({
+      Text: 'front<br>text<br><br>back<br>text',
     });
   });
 });

--- a/packages/shared/src/import-parsers.ts
+++ b/packages/shared/src/import-parsers.ts
@@ -282,10 +282,12 @@ export function mapCardFields(
   back: string,
   model: string
 ): Record<string, string> {
+  const f = front.replace(/\n/g, '<br>');
+  const b = back.replace(/\n/g, '<br>');
   if (model === ANKI_MODELS.CLOZE) {
-    return { Text: `${front}\n\n${back}` };
+    return { Text: `${f}<br><br>${b}` };
   }
-  return { Front: front, Back: back };
+  return { Front: f, Back: b };
 }
 
 /**


### PR DESCRIPTION
## Summary
- Extends the `\n → <br>` fix from the `note add` command to all import paths (CSV, JSON, Markdown)
- Fix is in `packages/shared/src/import-parsers.ts` `mapCardFields()`, which is the single call-site for all three import routes
- For Cloze model, the separator is also updated from `\n\n` to `<br><br>` for consistency
- Added a test case covering newline conversion for Basic and Cloze models

Closes #85

## Test plan
- [x] `\n → <br>` applied to Front and Back for Basic/unknown models
- [x] `\n → <br>` applied within fields and separator for Cloze
- [x] All 61 shared package tests pass

🤖 Generated with [Claude Code](https://claude.ai/claude-code)