### PR TITLE
#89 Add deckName to JSON export, overridable on export and import

### DIFF
--- a/apps/cli/src/__tests__/export.test.ts
+++ b/apps/cli/src/__tests__/export.test.ts
@@ -217,6 +217,7 @@ describe('export command', () => {
       expect(parsed).toHaveLength(2);
       expect(parsed[0]).toMatchObject({
         noteId: 101,
+        deckName: 'TypeScript',
         modelName: 'Basic',
         tags: ['ts', 'beginner'],
         fields: {
@@ -230,6 +231,31 @@ describe('export command', () => {
       await run(['TypeScript', '/tmp/out.json', '--format', 'json']);
 
       expect(mockClient.exportPackage).not.toHaveBeenCalled();
+    });
+
+    it('uses source deck name as deckName by default', async () => {
+      await run(['TypeScript', '/tmp/out.json', '--format', 'json']);
+
+      const raw: string = mockWriteFileSync.mock.calls[0][1] as string;
+      const parsed = JSON.parse(raw);
+      expect(parsed[0].deckName).toBe('TypeScript');
+    });
+
+    it('overrides deckName with --deck-name', async () => {
+      await run([
+        'TypeScript',
+        '/tmp/out.json',
+        '--format',
+        'json',
+        '--deck-name',
+        'Grammar',
+      ]);
+
+      const raw: string = mockWriteFileSync.mock.calls[0][1] as string;
+      const parsed = JSON.parse(raw);
+      parsed.forEach((record: any) => {
+        expect(record.deckName).toBe('Grammar');
+      });
     });
   });
 

--- a/apps/cli/src/commands/export.ts
+++ b/apps/cli/src/commands/export.ts
@@ -51,7 +51,7 @@ function notesToCsv(notes: NoteInfo[]): string {
   return `${[header, ...rows].join('\n')}\n`;
 }
 
-function notesToJson(notes: NoteInfo[]): string {
+function notesToJson(notes: NoteInfo[], deckName: string): string {
   const records = notes.map(note => {
     const fields: Record<string, string> = {};
     for (const [name, { value }] of Object.entries(note.fields)) {
@@ -59,6 +59,7 @@ function notesToJson(notes: NoteInfo[]): string {
     }
     return {
       noteId: note.noteId,
+      deckName,
       modelName: note.modelName,
       tags: note.tags,
       fields,
@@ -87,6 +88,10 @@ export function createExportCommand(): Command {
       '--include-sched',
       'Include scheduling/review history data (apkg only)'
     )
+    .option(
+      '--deck-name <name>',
+      'Override the deckName written into JSON output (default: source deck name)'
+    )
     .action(
       async (
         deck: string,
@@ -95,6 +100,7 @@ export function createExportCommand(): Command {
           format: string;
           query?: string;
           includeSched?: boolean;
+          deckName?: string;
         }
       ) => {
         const format = options.format as Format;
@@ -212,7 +218,9 @@ export function createExportCommand(): Command {
         const writeSpinner = ora(`Writing ${format.toUpperCase()}…`).start();
         try {
           const content =
-            format === 'csv' ? notesToCsv(notes) : notesToJson(notes);
+            format === 'csv'
+              ? notesToCsv(notes)
+              : notesToJson(notes, options.deckName ?? deck);
           fs.writeFileSync(outputPath, content, 'utf8');
 
           const size = fs.statSync(outputPath).size;

--- a/apps/cli/src/commands/import.ts
+++ b/apps/cli/src/commands/import.ts
@@ -17,6 +17,7 @@ interface ImportOptions {
   format?: ImportFormat;
   delimiter?: string;
   deck?: string;
+  deckName?: string;
   model?: string;
   tags?: string;
   preview?: boolean;
@@ -49,6 +50,10 @@ export const importCommand = new Command('import')
   .option('-p, --preview', 'Preview import without creating cards')
   .option('--dry-run', "Dry run - validate but don't create cards")
   .option('--mapping <mapping>', 'Custom column mapping for CSV (JSON string)')
+  .option(
+    '--deck-name <deckName>',
+    'Override deck for all cards — takes priority over deckName in the file'
+  )
   .action(async (filePath: string, options: ImportOptions) => {
     const config = loadConfig();
     const baseUrl = config.serverUrl;
@@ -158,6 +163,7 @@ async function importJson(
     defaultTags: options.tags ? options.tags.split(',').map(t => t.trim()) : [],
     dryRun: options.preview || options.dryRun || false,
     validate: true,
+    deckOverride: options.deckName,
   };
 
   const formData = new FormData();

--- a/packages/shared/src/__tests__/import-parsers.test.ts
+++ b/packages/shared/src/__tests__/import-parsers.test.ts
@@ -230,6 +230,50 @@ describe('processJsonCards', () => {
     expect(cards[0].deck).toBe('CardDeck');
   });
 
+  it('reads deckName from each card', () => {
+    const data = [{ front: 'Q', back: 'A', deckName: 'English::Writing' }];
+    const opts = JsonImportOptionsSchema.parse({});
+    const cards = processJsonCards(data, opts);
+    expect(cards[0].deck).toBe('English::Writing');
+  });
+
+  it('deckOverride trumps per-card deckName and deck', () => {
+    const data = [
+      { front: 'Q', back: 'A', deckName: 'FromFile', deck: 'LegacyField' },
+    ];
+    const opts = JsonImportOptionsSchema.parse({ deckOverride: 'ForcedDeck' });
+    const cards = processJsonCards(data, opts);
+    expect(cards[0].deck).toBe('ForcedDeck');
+  });
+
+  it('priority: deckOverride > deckName > deck > defaultDeck', () => {
+    const data = [
+      { front: 'Q', back: 'A', deckName: 'FileLevel', deck: 'Legacy' },
+    ];
+    expect(
+      processJsonCards(
+        data,
+        JsonImportOptionsSchema.parse({
+          deckOverride: 'Override',
+          defaultDeck: 'Fallback',
+        })
+      )[0].deck
+    ).toBe('Override');
+    expect(
+      processJsonCards(
+        data,
+        JsonImportOptionsSchema.parse({ defaultDeck: 'Fallback' })
+      )[0].deck
+    ).toBe('FileLevel');
+    const noNames = [{ front: 'Q', back: 'A', deck: 'Legacy' }];
+    expect(
+      processJsonCards(
+        noNames,
+        JsonImportOptionsSchema.parse({ defaultDeck: 'Fallback' })
+      )[0].deck
+    ).toBe('Legacy');
+  });
+
   it('merges card tags with default tags', () => {
     const opts = JsonImportOptionsSchema.parse({
       defaultTags: ['default-tag'],

--- a/packages/shared/src/import-parsers.ts
+++ b/packages/shared/src/import-parsers.ts
@@ -122,12 +122,14 @@ export const JsonImportOptionsSchema = z.object({
   defaultTags: z.array(z.string()).optional().default([]),
   dryRun: z.boolean().optional().default(false),
   validate: z.boolean().optional().default(true),
+  deckOverride: z.string().optional(),
 });
 
 export interface JsonCard {
   front: string;
   back: string;
   deck?: string;
+  deckName?: string;
   model?: string;
   tags?: string[];
   difficulty?: string;
@@ -175,7 +177,13 @@ export function processJsonCards(
     return {
       front: card.front.trim(),
       back: card.back.trim(),
-      deck: (card.deck || defaultDeck || 'Default').trim(),
+      deck: (
+        options.deckOverride ||
+        card.deckName ||
+        card.deck ||
+        defaultDeck ||
+        'Default'
+      ).trim(),
       model: (card.model || defaultModel).trim(),
       tags: allTags,
       difficulty: card.difficulty?.trim(),


### PR DESCRIPTION
## Summary
- **Export**: `notesToJson()` now writes `deckName` into every record (defaults to the source deck argument; `--deck-name` overrides it)
- **Import**: `processJsonCards` reads `deckName` from each card with priority: `--deck-name` CLI flag (`deckOverride`) > per-card `deckName` > per-card `deck` > `--deck` default > `'Default'`
- **CLI import** gains `--deck-name` option that acts as the highest-priority deck override

Example round-trip:
```bash
# Export — deckName written into each record
ankiniki export "English::Writing::Grammar" grammar.json --format json

# Import — reads deckName from the file, no flags needed
ankiniki note import grammar.json --format json

# Override on import
ankiniki note import grammar.json --format json --deck-name "Staging"
```

Closes #89

## Test plan
- [x] Exported JSON records contain `deckName` equal to the source deck
- [x] `--deck-name` on export overrides the written `deckName`
- [x] Import reads `deckName` per card
- [x] `deckOverride` (`--deck-name` on import) trumps per-card `deckName`
- [x] Full priority chain tested: `deckOverride > deckName > deck > defaultDeck`
- [x] 98 CLI tests + 64 shared tests pass

🤖 Generated with [Claude Code](https://claude.ai/claude-code)